### PR TITLE
feat(wizard): nav + pantallas base (M3) y MainActivity con NavHost

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,10 +1,9 @@
 name: Android CI
 
 on:
-  push:
-    branches: [ "clean", "main", "feature/**" ]
-  pull_request:
-    branches: [ "clean", "main" ]
+  workflow_dispatch:
+  
+    
 
 jobs:
   build:

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -18,10 +18,23 @@ jobs:
         with:
           distribution: temurin
           java-version: "17"
-          cache: gradle
 
-      - name: Make gradlew executable
-        run: chmod +x ./gradlew
+      # Instala Android SDK y herramientas de línea de comandos
+      - name: Install Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install SDK packages (platforms/build-tools) and accept licenses
+        run: |
+          sdkmanager --install \
+            "platform-tools" \
+            "platforms;android-34" \
+            "build-tools;34.0.0" \
+            "cmdline-tools;latest"
+          yes | sdkmanager --licenses
+
+      # Cache de Gradle (opcional pero acelera)
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Build Debug
         run: ./gradlew clean assembleDebug --stacktrace

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,27 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ "clean", "main", "feature/**" ]
+  pull_request:
+    branches: [ "clean", "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Build Debug
+        run: ./gradlew clean assembleDebug --stacktrace

--- a/00-onboarding+users-bottom-bar-v2.patch
+++ b/00-onboarding+users-bottom-bar-v2.patch
@@ -1,0 +1,671 @@
+*** Begin Patch
+*** Add File: app/src/main/java/com/deercom/testo11/nav/NewRoutes.kt
++package com.deercom.testo11.nav
++
++object NewRoutes {
++    const val ONBOARDING = "onboarding"
++    const val LOGIN_USER_PASS = "login_user_pass"
++    const val HOME = "home_new"
++}
++
+*** End Patch
+*** Begin Patch
+*** Add File: app/src/main/java/com/deercom/testo11/nav/NewAppNavGraph.kt
++package com.deercom.testo11.nav
++
++import androidx.compose.runtime.Composable
++import androidx.navigation.compose.NavHost
++import androidx.navigation.compose.composable
++import androidx.navigation.compose.rememberNavController
++import com.deercom.testo11.login.LoginUserPassScreen
++import com.deercom.testo11.ui.screens.home.HomeWithBottomBarScreen
++import com.deercom.testo11.ui.screens.onboarding.OnboardingScreen
++
++@Composable
++fun NewAppNavGraph() {
++    val nav = rememberNavController()
++    NavHost(navController = nav, startDestination = NewRoutes.ONBOARDING) {
++        // Alta unificada
++        composable(NewRoutes.ONBOARDING) {
++            OnboardingScreen(
++                onFinishFirstTime = {
++                    nav.navigate(NewRoutes.LOGIN_USER_PASS) {
++                        popUpTo(NewRoutes.ONBOARDING) { inclusive = true }
++                    }
++                },
++                onFinishFromHome = { nav.popBackStack() }
++            )
++        }
++        // Login usuario + contraseña (modo pruebas)
++        composable(NewRoutes.LOGIN_USER_PASS) {
++            LoginUserPassScreen(
++                onSuccess = {
++                    nav.navigate(NewRoutes.HOME) {
++                        popUpTo(NewRoutes.LOGIN_USER_PASS) { inclusive = true }
++                    }
++                },
++                onBack = { nav.popBackStack() }
++            )
++        }
++        // Home con bottom bar (Usuarios por defecto)
++        composable(NewRoutes.HOME) {
++            HomeWithBottomBarScreen(
++                onEditUser = {
++                    // Abrir Onboarding para "editar" (modo pruebas: reusamos la misma pantalla)
++                    nav.navigate(NewRoutes.ONBOARDING)
++                }
++            )
++        }
++    }
++}
++
+*** End Patch
+*** Begin Patch
+*** Add File: app/src/main/java/com/deercom/testo11/data/Models.kt
++package com.deercom.testo11.data
++
++data class User(
++    val alias: String = "",
++    val nombres: String = "",
++    val apellidos: String = "",
++    val cargo: String = "",
++    val documento: String = "",
++    val telefonoPersonal: String = "",
++    val telefonoDispositivo: String = "",
++    val localidad: String = "",
++    val fotoUri: String = "",
++    val passwordHash: String = "" // modo pruebas: hash simple (SHA-256)
++)
++
+*** End Patch
+*** Begin Patch
+*** Add File: app/src/main/java/com/deercom/testo11/data/LocalUserRepository.kt
++package com.deercom.testo11.data
++
++import android.content.Context
++import androidx.datastore.preferences.core.Preferences
++import androidx.datastore.preferences.core.edit
++import androidx.datastore.preferences.core.stringSetPreferencesKey
++import androidx.datastore.preferences.preferencesDataStore
++import dagger.hilt.android.qualifiers.ApplicationContext
++import kotlinx.coroutines.flow.Flow
++import kotlinx.coroutines.flow.map
++import java.security.MessageDigest
++import javax.inject.Inject
++import javax.inject.Singleton
++
++private val Context.ds by preferencesDataStore(name = "local_users")
++
++@Singleton
++class LocalUserRepository @Inject constructor(
++    @ApplicationContext private val context: Context
++) {
++    private object K {
++        val USERS: Preferences.Key<Set<String>> = stringSetPreferencesKey("users_set")
++        val CARGOS: Preferences.Key<Set<String>> = stringSetPreferencesKey("cargos_set")
++        val LOCALIDADES: Preferences.Key<Set<String>> = stringSetPreferencesKey("localidades_set")
++    }
++
++    // -------- Encoding simple (sin libs externas) --------
++    private fun encode(user: User): String =
++        listOf(
++            user.alias, user.nombres, user.apellidos, user.cargo, user.documento,
++            user.telefonoPersonal, user.telefonoDispositivo, user.localidad, user.fotoUri, user.passwordHash
++        ).joinToString(separator = "§") // separador poco común
++
++    private fun decode(s: String): User {
++        val parts = s.split("§")
++        return User(
++            alias = parts.getOrNull(0) ?: "",
++            nombres = parts.getOrNull(1) ?: "",
++            apellidos = parts.getOrNull(2) ?: "",
++            cargo = parts.getOrNull(3) ?: "",
++            documento = parts.getOrNull(4) ?: "",
++            telefonoPersonal = parts.getOrNull(5) ?: "",
++            telefonoDispositivo = parts.getOrNull(6) ?: "",
++            localidad = parts.getOrNull(7) ?: "",
++            fotoUri = parts.getOrNull(8) ?: "",
++            passwordHash = parts.getOrNull(9) ?: ""
++        )
++    }
++
++    fun usersFlow(): Flow<List<User>> =
++        context.ds.data.map { it[K.USERS].orEmpty().map(::decode) }
++
++    suspend fun upsertUser(u: User) {
++        context.ds.edit { prefs ->
++            val all = prefs[K.USERS].orEmpty().toMutableSet()
++            // remove old with same alias
++            val without = all.filterNot { decode(it).alias.equals(u.alias, ignoreCase = true) }.toMutableSet()
++            without.add(encode(u))
++            prefs[K.USERS] = without
++            if (u.cargo.isNotBlank()) prefs[K.CARGOS] = prefs[K.CARGOS].orEmpty() + u.cargo
++            if (u.localidad.isNotBlank()) prefs[K.LOCALIDADES] = prefs[K.LOCALIDADES].orEmpty() + u.localidad
++        }
++    }
++
++    fun cargosFlow(): Flow<List<String>> =
++        context.ds.data.map { it[K.CARGOS].orEmpty().sorted() }
++
++    fun localidadesFlow(): Flow<List<String>> =
++        context.ds.data.map { it[K.LOCALIDADES].orEmpty().sorted() }
++
++    // Hash simple (modo pruebas) con SHA-256
++    fun sha256(text: String): String {
++        val md = MessageDigest.getInstance("SHA-256")
++        val bytes = md.digest(text.toByteArray(Charsets.UTF_8))
++        return bytes.joinToString("") { "%02x".format(it) }
++    }
++}
++
+*** End Patch
+*** Begin Patch
+*** Add File: app/src/main/java/com/deercom/testo11/onboarding/OnboardingViewModel.kt
++package com.deercom.testo11.onboarding
++
++import androidx.lifecycle.ViewModel
++import androidx.lifecycle.viewModelScope
++import com.deercom.testo11.data.LocalUserRepository
++import com.deercom.testo11.data.User
++import dagger.hilt.android.lifecycle.HiltViewModel
++import kotlinx.coroutines.flow.MutableStateFlow
++import kotlinx.coroutines.flow.StateFlow
++import kotlinx.coroutines.launch
++import java.text.Normalizer
++import javax.inject.Inject
++
++@HiltViewModel
++class OnboardingViewModel @Inject constructor(
++    private val repo: LocalUserRepository
++) : ViewModel() {
++
++    data class UiState(
++        val empresaNombre: String = "",
++        val ruc: String = "",
++        val localidad: String = "",
++        val alias: String = "",
++        val nombres: String = "",
++        val apellidos: String = "",
++        val cargo: String = "",
++        val documento: String = "",
++        val telefonoPersonal: String = "",
++        val telefonoDispositivo: String = "",
++        val fotoUri: String = "",
++        val password: String = "",
++        val passwordConfirm: String = ""
++    )
++
++    private val _state = MutableStateFlow(UiState())
++    val state: StateFlow<UiState> = _state
++
++    fun update(transform: (UiState) -> UiState) {
++        _state.value = transform(_state.value)
++    }
++
++    fun regenerateAlias() {
++        val s = _state.value
++        val initial = s.nombres.trim().firstOrNull()?.lowercase() ?: ""
++        val apellido = s.apellidos.trim().split(" ").firstOrNull()?.lowercase().orEmpty()
++        val loc = s.localidad.trim().lowercase()
++        val base = (initial + apellido + if (loc.isNotBlank()) ".$loc" else "")
++        val normalized = Normalizer.normalize(base, Normalizer.Form.NFD)
++            .replace("\\p{InCombiningDiacriticalMarks}+".toRegex(), "")
++            .replace("[^a-z0-9._]".toRegex(), "")
++        update { it.copy(alias = normalized) }
++    }
++
++    fun save(onSaved: () -> Unit) {
++        val s = _state.value
++        viewModelScope.launch {
++            val user = User(
++                alias = s.alias.ifBlank { "usuario" },
++                nombres = s.nombres,
++                apellidos = s.apellidos,
++                cargo = s.cargo,
++                documento = s.documento,
++                telefonoPersonal = s.telefonoPersonal,
++                telefonoDispositivo = s.telefonoDispositivo,
++                localidad = s.localidad,
++                fotoUri = s.fotoUri,
++                passwordHash = repo.sha256(s.password)
++            )
++            repo.upsertUser(user)
++            onSaved()
++        }
++    }
++}
++
+*** End Patch
+*** Begin Patch
+*** Add File: app/src/main/java/com/deercom/testo11/ui/screens/onboarding/OnboardingScreen.kt
++package com.deercom.testo11.ui.screens.onboarding
++
++import androidx.compose.foundation.layout.*
++import androidx.compose.material.icons.Icons
++import androidx.compose.material.icons.filled.ArrowBack
++import androidx.compose.material.icons.filled.Business
++import androidx.compose.material.icons.filled.Lock
++import androidx.compose.material.icons.filled.Person
++import androidx.compose.material.icons.filled.PhotoCamera
++import androidx.compose.material3.*
++import androidx.compose.runtime.*
++import androidx.compose.ui.Alignment
++import androidx.compose.ui.Modifier
++import androidx.compose.ui.text.input.ImeAction
++import androidx.compose.ui.text.input.KeyboardOptions
++import androidx.compose.ui.text.input.VisualTransformation
++import androidx.compose.ui.text.input.PasswordVisualTransformation
++import androidx.compose.ui.unit.dp
++import androidx.hilt.navigation.compose.hiltViewModel
++import com.deercom.testo11.onboarding.OnboardingViewModel
++import com.deercom.testo11.ui.screens.components.AppScaffold
++import com.deercom.testo11.ui.screens.components.AppTopBar
++
++@Composable
++fun OnboardingScreen(
++    onFinishFirstTime: () -> Unit,
++    onFinishFromHome: () -> Unit
++) {
++    val vm: OnboardingViewModel = hiltViewModel()
++    val s by vm.state.collectAsState()
++
++    var tab by remember { mutableStateOf(0) }
++    val tabs = listOf("Empresa", "Perfil", "Seguridad", "Foto")
++
++    AppScaffold(
++        topBar = {
++            AppTopBar(
++                title = "Alta inicial",
++                navigationIcon = Icons.Filled.ArrowBack,
++                onNavigate = { /* back se maneja desde NavGraph */ }
++            )
++        }
++    ) { pad ->
++        Column(
++            modifier = Modifier
++                .padding(pad)
++                .fillMaxSize()
++                .imePadding(),
++            horizontalAlignment = Alignment.CenterHorizontally
++        ) {
++            ScrollableTabRow(selectedTabIndex = tab) {
++                tabs.forEachIndexed { i, title ->
++                    Tab(
++                        selected = tab == i,
++                        onClick = { tab = i },
++                        text = { Text(title) }
++                    )
++                }
++            }
++
++            Card(
++                modifier = Modifier
++                    .padding(16.dp)
++                    .fillMaxWidth()
++                    .widthIn(max = 480.dp),
++                elevation = CardDefaults.cardElevation(2.dp)
++            ) {
++                Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
++                    when (tab) {
++                        0 -> EmpresaTab(s, vm)
++                        1 -> PerfilTab(s, vm)
++                        2 -> SeguridadTab(s, vm)
++                        3 -> FotoTab(s, vm)
++                    }
++                    Spacer(Modifier.height(8.dp))
++                    Row(horizontalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.fillMaxWidth()) {
++                        OutlinedButton(
++                            onClick = { vm.save(onSaved = onFinishFromHome) },
++                            modifier = Modifier.weight(1f)
++                        ) { Text("Guardar borrador") }
++                        Button(
++                            onClick = { vm.save(onSaved = onFinishFirstTime) },
++                            modifier = Modifier.weight(1f)
++                        ) { Text("Guardar y finalizar") }
++                    }
++                }
++            }
++        }
++    }
++}
++
++@Composable
++private fun EmpresaTab(s: OnboardingViewModel.UiState, vm: OnboardingViewModel) {
++    OutlinedTextField(
++        value = s.empresaNombre,
++        onValueChange = { new -> vm.update { it.copy(empresaNombre = new) } },
++        label = { Text("Nombre de la empresa") },
++        leadingIcon = { Icon(Icons.Filled.Business, null) },
++        modifier = Modifier.fillMaxWidth()
++    )
++    OutlinedTextField(
++        value = s.ruc,
++        onValueChange = { new -> vm.update { it.copy(ruc = new) } },
++        label = { Text("RUC / NIT / ID fiscal") },
++        modifier = Modifier.fillMaxWidth()
++    )
++    OutlinedTextField(
++        value = s.localidad,
++        onValueChange = { new -> vm.update { it.copy(localidad = new) } },
++        label = { Text("Localidad (código)") },
++        modifier = Modifier.fillMaxWidth()
++    )
++    AssistChip(onClick = { vm.regenerateAlias() }, label = { Text("Sugerir alias con localidad") })
++}
++
++@Composable
++private fun PerfilTab(s: OnboardingViewModel.UiState, vm: OnboardingViewModel) {
++    OutlinedTextField(
++        value = s.alias,
++        onValueChange = { new -> vm.update { it.copy(alias = new) } },
++        label = { Text("Usuario (alias)") },
++        leadingIcon = { Icon(Icons.Filled.Person, null) },
++        modifier = Modifier.fillMaxWidth()
++    )
++    Row(horizontalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.fillMaxWidth()) {
++        OutlinedTextField(
++            value = s.nombres,
++            onValueChange = { new -> vm.update { it.copy(nombres = new) } },
++            label = { Text("Nombres") },
++            modifier = Modifier.weight(1f),
++            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next)
++        )
++        OutlinedTextField(
++            value = s.apellidos,
++            onValueChange = { new -> vm.update { it.copy(apellidos = new) } },
++            label = { Text("Apellidos") },
++            modifier = Modifier.weight(1f),
++            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done)
++        )
++    }
++    OutlinedTextField(
++        value = s.cargo,
++        onValueChange = { new -> vm.update { it.copy(cargo = new) } },
++        label = { Text("Cargo") },
++        modifier = Modifier.fillMaxWidth()
++    )
++    OutlinedTextField(
++        value = s.documento,
++        onValueChange = { new -> vm.update { it.copy(documento = new) } },
++        label = { Text("Documento (ID)") },
++        modifier = Modifier.fillMaxWidth()
++    )
++    OutlinedTextField(
++        value = s.telefonoPersonal,
++        onValueChange = { new -> vm.update { it.copy(telefonoPersonal = new) } },
++        label = { Text("Teléfono personal") },
++        modifier = Modifier.fillMaxWidth()
++    )
++    OutlinedTextField(
++        value = s.telefonoDispositivo,
++        onValueChange = { new -> vm.update { it.copy(telefonoDispositivo = new) } },
++        label = { Text("Teléfono del dispositivo") },
++        trailingIcon = {
++            AssistChip(onClick = { /* Placeholder: Phone Number Hint en implementación */ }, label = { Text("Sugerir número") })
++        },
++        modifier = Modifier.fillMaxWidth()
++    )
++}
++
++@Composable
++private fun SeguridadTab(s: OnboardingViewModel.UiState, vm: OnboardingViewModel) {
++    var show1 by remember { mutableStateOf(false) }
++    var show2 by remember { mutableStateOf(false) }
++    OutlinedTextField(
++        value = s.password,
++        onValueChange = { new -> vm.update { it.copy(password = new) } },
++        label = { Text("Contraseña") },
++        visualTransformation = if (show1) VisualTransformation.None else PasswordVisualTransformation(),
++        trailingIcon = {
++            TextButton(onClick = { show1 = !show1 }) { Text(if (show1) "Ocultar" else "Ver") }
++        },
++        modifier = Modifier.fillMaxWidth()
++    )
++    OutlinedTextField(
++        value = s.passwordConfirm,
++        onValueChange = { new -> vm.update { it.copy(passwordConfirm = new) } },
++        label = { Text("Confirmar contraseña") },
++        visualTransformation = if (show2) VisualTransformation.None else PasswordVisualTransformation(),
++        trailingIcon = {
++            TextButton(onClick = { show2 = !show2 }) { Text(if (show2) "Ocultar" else "Ver") }
++        },
++        modifier = Modifier.fillMaxWidth()
++    )
++    // Indicador simple (informativo)
++    LinearProgressIndicator(progress = { (s.password.length.coerceAtMost(12)) / 12f })
++}
++
++@Composable
++private fun FotoTab(s: OnboardingViewModel.UiState, vm: OnboardingViewModel) {
++    OutlinedTextField(
++        value = s.fotoUri,
++        onValueChange = { new -> vm.update { it.copy(fotoUri = new) } },
++        label = { Text("Foto (URI)") },
++        leadingIcon = { Icon(Icons.Filled.PhotoCamera, null) },
++        modifier = Modifier.fillMaxWidth()
++    )
++    Text("En producción: tomar foto / galería + recorte y compresión.")
++}
++
+*** End Patch
+*** Begin Patch
+*** Add File: app/src/main/java/com/deercom/testo11/login/LoginUserPassScreen.kt
++package com.deercom.testo11.login
++
++import androidx.compose.foundation.layout.*
++import androidx.compose.material.icons.automirrored.filled.Login
++import androidx.compose.material3.*
++import androidx.compose.runtime.*
++import androidx.compose.ui.Modifier
++import androidx.compose.ui.text.input.PasswordVisualTransformation
++import androidx.compose.ui.unit.dp
++import com.deercom.testo11.ui.screens.components.AppScaffold
++import com.deercom.testo11.ui.screens.components.AppTopBar
++
++@Composable
++fun LoginUserPassScreen(
++    onSuccess: () -> Unit,
++    onBack: () -> Unit
++) {
++    var alias by remember { mutableStateOf("") }
++    var pass by remember { mutableStateOf("") }
++
++    AppScaffold(
++        topBar = { AppTopBar(title = "Iniciar sesión") }
++    ) { pad ->
++        Column(
++            modifier = Modifier
++                .padding(pad)
++                .padding(16.dp)
++                .fillMaxWidth(),
++            verticalArrangement = Arrangement.spacedBy(12.dp)
++        ) {
++            OutlinedTextField(
++                value = alias, onValueChange = { alias = it },
++                label = { Text("Usuario") },
++                leadingIcon = { Icon(Icons.AutoMirrored.Filled.Login, null) },
++                singleLine = true, modifier = Modifier.fillMaxWidth()
++            )
++            OutlinedTextField(
++                value = pass, onValueChange = { pass = it },
++                label = { Text("Contraseña") },
++                visualTransformation = PasswordVisualTransformation(),
++                singleLine = true, modifier = Modifier.fillMaxWidth()
++            )
++            Button(
++                onClick = { onSuccess() }, // modo pruebas
++                enabled = alias.isNotBlank()
++            ) { Text("Entrar") }
++        }
++    }
++}
++
+*** End Patch
+*** Begin Patch
+*** Add File: app/src/main/java/com/deercom/testo11/users/UsersViewModel.kt
++package com.deercom.testo11.users
++
++import androidx.lifecycle.ViewModel
++import com.deercom.testo11.data.LocalUserRepository
++import com.deercom.testo11.data.User
++import dagger.hilt.android.lifecycle.HiltViewModel
++import kotlinx.coroutines.flow.SharingStarted
++import kotlinx.coroutines.flow.StateFlow
++import kotlinx.coroutines.flow.map
++import kotlinx.coroutines.flow.stateIn
++import javax.inject.Inject
++
++@HiltViewModel
++class UsersViewModel @Inject constructor(
++    repo: LocalUserRepository
++) : ViewModel() {
++    val users: StateFlow<List<User>> =
++        repo.usersFlow().map { it.sortedBy { u -> u.alias } }
++            .stateIn(kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.Main), SharingStarted.Lazily, emptyList())
++}
++
+*** End Patch
+*** Begin Patch
+*** Add File: app/src/main/java/com/deercom/testo11/ui/screens/users/UsersListScreen.kt
++package com.deercom.testo11.ui.screens.users
++
++import androidx.compose.foundation.clickable
++import androidx.compose.foundation.layout.*
++import androidx.compose.foundation.lazy.LazyColumn
++import androidx.compose.foundation.lazy.items
++import androidx.compose.material.icons.Icons
++import androidx.compose.material.icons.filled.Edit
++import androidx.compose.material.icons.filled.Groups
++import androidx.compose.material3.*
++import androidx.compose.runtime.*
++import androidx.compose.ui.Modifier
++import androidx.compose.ui.unit.dp
++import androidx.hilt.navigation.compose.hiltViewModel
++import com.deercom.testo11.data.User
++import com.deercom.testo11.users.UsersViewModel
++
++@Composable
++fun UsersListScreen(
++    onEdit: (User) -> Unit
++) {
++    val vm: UsersViewModel = hiltViewModel()
++    val users by vm.users.collectAsState()
++
++    var selected by remember { mutableStateOf<User?>(null) }
++
++    Column(Modifier.fillMaxSize().padding(16.dp)) {
++        ListItem(
++            leadingContent = { Icon(Icons.Filled.Groups, null) },
++            headlineContent = { Text("Usuarios (${users.size})") },
++            supportingContent = { Text("Toque un usuario para ver detalle") }
++        )
++        Spacer(Modifier.height(8.dp))
++        LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxSize()) {
++            items(users) { u ->
++                ElevatedCard(
++                    modifier = Modifier.fillMaxWidth().clickable { selected = u }
++                ) {
++                    ListItem(
++                        headlineContent = { Text("${u.nombres} ${u.apellidos}".trim()) },
++                        supportingContent = { Text("${u.alias} • ${u.cargo.ifBlank { "Sin cargo" }}") }
++                    )
++                }
++            }
++        }
++    }
++
++    if (selected != null) {
++        val u = selected!!
++        AlertDialog(
++            onDismissRequest = { selected = null },
++            confirmButton = {
++                TextButton(onClick = { onEdit(u); selected = null }) {
++                    Icon(Icons.Filled.Edit, null); Spacer(Modifier.width(6.dp)); Text("Editar")
++                }
++            },
++            dismissButton = { TextButton(onClick = { selected = null }) { Text("Cerrar") } },
++            title = { Text("${u.nombres} ${u.apellidos}".trim()) },
++            text = {
++                Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
++                    Text("Usuario: ${u.alias}")
++                    Text("Cargo: ${u.cargo.ifBlank { "—" }}")
++                    Text("Documento: ${u.documento.ifBlank { "—" }}")
++                    Text("Tel. personal: ${u.telefonoPersonal.ifBlank { "—" }}")
++                    Text("Tel. dispositivo: ${u.telefonoDispositivo.ifBlank { "—" }}")
++                    Text("Localidad: ${u.localidad.ifBlank { "—" }}")
++                }
++            }
++        )
++    }
++}
++
+*** End Patch
+*** Begin Patch
+*** Add File: app/src/main/java/com/deercom/testo11/ui/screens/home/HomeWithBottomBarScreen.kt
++package com.deercom.testo11.ui.screens.home
++
++import androidx.compose.material.icons.Icons
++import androidx.compose.material.icons.filled.Business
++import androidx.compose.material.icons.filled.Home
++import androidx.compose.material.icons.filled.Settings
++import androidx.compose.material.icons.filled.Groups
++import androidx.compose.material3.*
++import androidx.compose.runtime.*
++import androidx.compose.ui.Modifier
++import androidx.compose.foundation.layout.*
++import androidx.compose.ui.unit.dp
++import com.deercom.testo11.data.User
++import com.deercom.testo11.ui.screens.components.AppScaffold
++import com.deercom.testo11.ui.screens.components.AppTopBar
++import com.deercom.testo11.ui.screens.users.UsersListScreen
++
++@Composable
++fun HomeWithBottomBarScreen(
++    onEditUser: (User) -> Unit
++) {
++    var tab by remember { mutableStateOf(0) }
++    val items = listOf("Usuarios", "Inicio", "Empresa", "Ajustes")
++    val icons = listOf(Icons.Filled.Groups, Icons.Filled.Home, Icons.Filled.Business, Icons.Filled.Settings)
++
++    AppScaffold(
++        topBar = { AppTopBar(title = items[tab]) }
++    ) { pad ->
++        Scaffold(
++            modifier = Modifier.padding(pad),
++            bottomBar = {
++                NavigationBar {
++                    items.forEachIndexed { index, label ->
++                        NavigationBarItem(
++                            selected = tab == index,
++                            onClick = { tab = index },
++                            icon = { Icon(icons[index], contentDescription = label) },
++                            label = { Text(label) }
++                        )
++                    }
++                }
++            }
++        ) { inner ->
++            Box(Modifier.padding(inner).fillMaxSize()) {
++                when (tab) {
++                    0 -> UsersListScreen(onEdit = onEditUser)
++                    1 -> Placeholder("Inicio")
++                    2 -> Placeholder("Empresa")
++                    3 -> Placeholder("Ajustes")
++                }
++            }
++        }
++    }
++}
++
++@Composable
++private fun Placeholder(text: String) {
++    Column(
++        modifier = Modifier.fillMaxSize().padding(16.dp),
++        verticalArrangement = Arrangement.spacedBy(8.dp)
++    ) {
++        Text("Sección: $text")
++        Text("Contenido en construcción.")
++    }
++}
++
+*** End Patch

--- a/00-onboarding-v2.1-stepper-summary.patch
+++ b/00-onboarding-v2.1-stepper-summary.patch
@@ -1,0 +1,514 @@
+*** Begin Patch
+*** Update File: app/src/main/java/com/deercom/testo11/nav/NewRoutes.kt
+@@
+-package com.deercom.testo11.nav
++package com.deercom.testo11.nav
+ 
+ enum class NewRoutes(val route: String) {
+-    Onboarding("onboarding"),
++    StartRouter("start"),
++    Onboarding("onboarding"),
++    Summary("summary"),
+     Login("login"),
+     Home("home")
+ }
+*** End Patch
+*** Begin Patch
+*** Update File: app/src/main/java/com/deercom/testo11/nav/NewAppNavGraph.kt
+@@
+ package com.deercom.testo11.nav
+ 
+ import androidx.compose.runtime.Composable
+ import androidx.navigation.compose.NavHost
+ import androidx.navigation.compose.composable
+ import androidx.navigation.compose.rememberNavController
++import androidx.hilt.navigation.compose.hiltViewModel
++import kotlinx.coroutines.flow.first
++import androidx.compose.runtime.LaunchedEffect
++import com.deercom.testo11.ui.screens.onboarding.OnboardingScreen
++import com.deercom.testo11.ui.screens.onboarding.SummaryScreen
++import com.deercom.testo11.login.LoginUserPassScreen
++import com.deercom.testo11.ui.screens.home.HomeWithBottomBarScreen
++import com.deercom.testo11.users.UsersViewModel
++import com.deercom.testo11.onboarding.OnboardingViewModel
++import com.deercom.testo11.data.LocalUserRepository
+ 
+ @Composable
+ fun NewAppNavGraph() {
+     val nav = rememberNavController()
+-    NavHost(navController = nav, startDestination = NewRoutes.Onboarding.route) {
+-        composable(NewRoutes.Onboarding.route) {
+-            com.deercom.testo11.ui.screens.onboarding.OnboardingScreen(
+-                onFinished = { nav.navigate(NewRoutes.Login.route) { popUpTo(0) } }
+-            )
+-        }
+-        composable(NewRoutes.Login.route) {
+-            com.deercom.testo11.login.LoginUserPassScreen(
+-                onLoginOk = { nav.navigate(NewRoutes.Home.route) { popUpTo(0) } }
+-            )
+-        }
+-        composable(NewRoutes.Home.route) {
+-            com.deercom.testo11.ui.screens.home.HomeWithBottomBarScreen(
+-                onEditUser = { /* future */ }
+-            )
+-        }
+-    }
++    NavHost(navController = nav, startDestination = NewRoutes.StartRouter.route) {
++        composable(NewRoutes.StartRouter.route) {
++            val repo: LocalUserRepository = hiltViewModel<UsersViewModel>().repo
++            LaunchedEffect(Unit) {
++                val setupDone = repo.isSetupDone().first()
++                val hasUsers = repo.hasAnyUser().first()
++                if (setupDone && hasUsers) {
++                    nav.navigate(NewRoutes.Login.route) { popUpTo(0) }
++                } else {
++                    nav.navigate(NewRoutes.Onboarding.route) { popUpTo(0) }
++                }
++            }
++        }
++        composable(NewRoutes.Onboarding.route) {
++            val vm: OnboardingViewModel = hiltViewModel()
++            OnboardingScreen(
++                vm = vm,
++                onGotoSummary = { nav.navigate(NewRoutes.Summary.route) }
++            )
++        }
++        composable(NewRoutes.Summary.route) {
++            val vm: OnboardingViewModel = hiltViewModel()
++            SummaryScreen(
++                vm = vm,
++                onEditSection = { section ->
++                    vm.goToSection(section)
++                    nav.popBackStack()
++                },
++                onConfirm = {
++                    nav.navigate(NewRoutes.Login.route) { popUpTo(0) }
++                }
++            )
++        }
++        composable(NewRoutes.Login.route) {
++            LoginUserPassScreen(
++                onLoginOk = { nav.navigate(NewRoutes.Home.route) { popUpTo(0) } }
++            )
++        }
++        composable(NewRoutes.Home.route) {
++            HomeWithBottomBarScreen(
++                onEditUser = { /* future */ }
++            )
++        }
++    }
+ }
+*** End Patch
+*** Begin Patch
+*** Update File: app/src/main/java/com/deercom/testo11/data/LocalUserRepository.kt
+@@
+ package com.deercom.testo11.data
+ 
+ import android.content.Context
+ import androidx.datastore.preferences.core.Preferences
+ import androidx.datastore.preferences.core.edit
++import androidx.datastore.preferences.core.booleanPreferencesKey
+ import androidx.datastore.preferences.core.stringPreferencesKey
+ import androidx.datastore.preferences.preferencesDataStore
+ import dagger.hilt.android.qualifiers.ApplicationContext
+ import kotlinx.coroutines.flow.Flow
+ import kotlinx.coroutines.flow.map
+@@
+ private val Context.userPrefs by preferencesDataStore("users_prefs")
+ 
+ class LocalUserRepository @Inject constructor(
+     @ApplicationContext private val context: Context
+ ) {
+     private object K {
+         val USERS: Preferences.Key<String> = stringPreferencesKey("users_json")
++        val SETUP_DONE: Preferences.Key<Boolean> = booleanPreferencesKey("setup_done")
+     }
+@@
+     suspend fun addUser(u: User) {
+         val current = users()
+         val updated = current + u
+         context.userPrefs.edit { it[K.USERS] = toJson(updated) }
+     }
++
++    fun hasAnyUser(): Flow<Boolean> = context.userPrefs.data.map { prefs ->
++        val json = prefs[K.USERS]
++        !json.isNullOrEmpty() && fromJson(json).isNotEmpty()
++    }
++
++    fun isSetupDone(): Flow<Boolean> =
++        context.userPrefs.data.map { prefs -> prefs[K.SETUP_DONE] ?: false }
++
++    suspend fun setSetupDone(value: Boolean) {
++        context.userPrefs.edit { it[K.SETUP_DONE] = value }
++    }
+ }
+*** End Patch
+*** Begin Patch
+*** Update File: app/src/main/java/com/deercom/testo11/onboarding/OnboardingViewModel.kt
+@@
+ package com.deercom.testo11.onboarding
+ 
+ import androidx.lifecycle.ViewModel
+ import androidx.lifecycle.viewModelScope
+ import com.deercom.testo11.data.LocalUserRepository
+ import com.deercom.testo11.data.User
+ import dagger.hilt.android.lifecycle.HiltViewModel
+ import kotlinx.coroutines.launch
+ import javax.inject.Inject
+ 
+ @HiltViewModel
+ class OnboardingViewModel @Inject constructor(
+     private val repo: LocalUserRepository
+ ) : ViewModel() {
+-    // empresa
++    // empresa
+     var companyName: String = ""
+     var companyId: String = ""
+ 
+     // perfil
+     var firstName: String = ""
+     var lastName: String = ""
+     var phone: String = ""
+ 
+     // seguridad
+     var username: String = ""
+     var password: String = ""
+ 
+     // foto (uri texto por simplicidad)
+     var photoUri: String? = null
+ 
+-    fun savePartial() { /* ya no se usa en v2.1 */ }
++    enum class Section { EMPRESA, PERFIL, SEGURIDAD, FOTO }
++    var current: Section = Section.EMPRESA
++        private set
++
++    fun next() {
++        current = when (current) {
++            Section.EMPRESA -> Section.PERFIL
++            Section.PERFIL -> Section.SEGURIDAD
++            Section.SEGURIDAD -> Section.FOTO
++            Section.FOTO -> Section.FOTO
++        }
++    }
++
++    fun back() {
++        current = when (current) {
++            Section.EMPRESA -> Section.EMPRESA
++            Section.PERFIL -> Section.EMPRESA
++            Section.SEGURIDAD -> Section.PERFIL
++            Section.FOTO -> Section.SEGURIDAD
++        }
++    }
++
++    fun goToSection(s: Section) { current = s }
+ 
+-    fun saveFinal(onDone: () -> Unit) {
++    fun saveAll(onDone: () -> Unit) {
+         viewModelScope.launch {
+             // crea usuario admin master mínimo con username/password y nombre
+             val user = User(
+                 id = username.ifBlank { "admin" },
+                 displayName = listOf(firstName, lastName).joinToString(" ").trim().ifBlank { "Admin" },
+                 phone = phone.ifBlank { null },
+                 role = "Admin Master"
+             )
+             repo.addUser(user)
++            repo.setSetupDone(true)
+             onDone()
+         }
+     }
+ }
+*** End Patch
+*** Begin Patch
+*** Update File: app/src/main/java/com/deercom/testo11/ui/screens/onboarding/OnboardingScreen.kt
+@@
+-package com.deercom.testo11.ui.screens.onboarding
++package com.deercom.testo11.ui.screens.onboarding
+ 
+ import androidx.compose.foundation.layout.Arrangement
+ import androidx.compose.foundation.layout.Column
+ import androidx.compose.foundation.layout.Row
+ import androidx.compose.foundation.layout.Spacer
+ import androidx.compose.foundation.layout.fillMaxSize
+ import androidx.compose.foundation.layout.fillMaxWidth
+ import androidx.compose.foundation.layout.height
+ import androidx.compose.foundation.layout.padding
+ import androidx.compose.material.icons.Icons
+ import androidx.compose.material.icons.filled.ArrowBack
+-import androidx.compose.material3.Button
++import androidx.compose.material3.Button
+ import androidx.compose.material3.Card
+ import androidx.compose.material3.MaterialTheme
+ import androidx.compose.material3.OutlinedTextField
+ import androidx.compose.material3.Text
+ import androidx.compose.runtime.Composable
+ import androidx.compose.runtime.mutableStateOf
+ import androidx.compose.runtime.remember
+ import androidx.compose.ui.Alignment
+ import androidx.compose.ui.Modifier
+ import androidx.compose.ui.unit.dp
+ import com.deercom.testo11.ui.screens.components.AppScaffold
+ import com.deercom.testo11.ui.screens.components.AppTopBar
++import androidx.compose.ui.text.input.KeyboardOptions
++import androidx.compose.ui.text.input.KeyboardType
++import androidx.compose.ui.text.input.ImeAction
++import androidx.compose.runtime.getValue
++import androidx.compose.runtime.setValue
++import androidx.activity.compose.rememberLauncherForActivityResult
++import androidx.activity.result.contract.ActivityResultContracts
++import androidx.compose.foundation.Image
++import androidx.compose.ui.layout.ContentScale
++import androidx.compose.ui.platform.LocalContext
++import coil.compose.rememberAsyncImagePainter
++import com.deercom.testo11.onboarding.OnboardingViewModel
+ 
+-@Composable
+-fun OnboardingScreen(onFinished: () -> Unit) {
++@Composable
++fun OnboardingScreen(
++    vm: OnboardingViewModel,
++    onGotoSummary: () -> Unit
++) {
+     AppScaffold(topBar = {
+         AppTopBar(
+             title = "Alta inicial",
+             navigationIcon = Icons.Filled.ArrowBack,
+             onNavigate = { /* back se maneja desde NavGraph */ },
+             actions = { com.deercom.testo11.ui.screens.components.TopBarOverflow() }
+         )
+     }) { pad ->
+-        Column(
++        Column(
+             modifier = Modifier
+                 .fillMaxSize()
+                 .padding(pad)
+                 .padding(16.dp),
+             verticalArrangement = Arrangement.spacedBy(16.dp)
+         ) {
+-            Card(modifier = Modifier.fillMaxWidth()) {
+-                Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+-                    Text("Empresa", style = MaterialTheme.typography.titleMedium)
+-                    val company = remember { mutableStateOf("") }
+-                    val ruc = remember { mutableStateOf("") }
+-                    OutlinedTextField(value = company.value, onValueChange = { company.value = it }, label = { Text("Nombre de empresa") })
+-                    OutlinedTextField(value = ruc.value, onValueChange = { ruc.value = it }, label = { Text("RUC/ID") }, keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number))
+-                }
+-            }
+-            Card(modifier = Modifier.fillMaxWidth()) {
+-                Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+-                    Text("Perfil", style = MaterialTheme.typography.titleMedium)
+-                    val first = remember { mutableStateOf("") }
+-                    val last = remember { mutableStateOf("") }
+-                    val phone = remember { mutableStateOf("") }
+-                    OutlinedTextField(value = first.value, onValueChange = { first.value = it }, label = { Text("Nombres") }, keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next))
+-                    OutlinedTextField(value = last.value, onValueChange = { last.value = it }, label = { Text("Apellidos") })
+-                    OutlinedTextField(value = phone.value, onValueChange = { phone.value = it }, label = { Text("Teléfono") }, keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone))
+-                }
+-            }
+-            Card(modifier = Modifier.fillMaxWidth()) {
+-                Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+-                    Text("Seguridad", style = MaterialTheme.typography.titleMedium)
+-                    val user = remember { mutableStateOf("") }
+-                    val pass = remember { mutableStateOf("") }
+-                    OutlinedTextField(value = user.value, onValueChange = { user.value = it }, label = { Text("Usuario/Alias") }, keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next))
+-                    OutlinedTextField(value = pass.value, onValueChange = { pass.value = it }, label = { Text("Contraseña") })
+-                }
+-            }
+-            Row(horizontalArrangement = Arrangement.spacedBy(12.dp), verticalAlignment = Alignment.CenterVertically) {
+-                Button(onClick = onFinished) { Text("Guardar y finalizar") }
+-            }
++            when (vm.current) {
++                com.deercom.testo11.onboarding.OnboardingViewModel.Section.EMPRESA -> EmpresaStep(vm)
++                com.deercom.testo11.onboarding.OnboardingViewModel.Section.PERFIL -> PerfilStep(vm)
++                com.deercom.testo11.onboarding.OnboardingViewModel.Section.SEGURIDAD -> SeguridadStep(vm)
++                com.deercom.testo11.onboarding.OnboardingViewModel.Section.FOTO -> FotoStep(vm)
++            }
++            Row(horizontalArrangement = Arrangement.spacedBy(12.dp), verticalAlignment = Alignment.CenterVertically) {
++                Button(onClick = { vm.back() }) { Text("Atrás") }
++                Spacer(Modifier.weight(1f))
++                if (vm.current == com.deercom.testo11.onboarding.OnboardingViewModel.Section.FOTO) {
++                    Button(onClick = onGotoSummary) { Text("Continuar a resumen") }
++                } else {
++                    Button(onClick = { vm.next() }) { Text("Siguiente") }
++                }
++            }
+         }
+     }
+ }
+ 
++@Composable
++private fun EmpresaStep(vm: OnboardingViewModel) {
++    Card(modifier = Modifier.fillMaxWidth()) {
++        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
++            Text("Empresa", style = MaterialTheme.typography.titleMedium)
++            OutlinedTextField(
++                value = vm.companyName, onValueChange = { vm.companyName = it },
++                label = { Text("Nombre de empresa") })
++            OutlinedTextField(
++                value = vm.companyId, onValueChange = { vm.companyId = it },
++                label = { Text("RUC/ID") },
++                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
++            )
++        }
++    }
++}
++
++@Composable
++private fun PerfilStep(vm: OnboardingViewModel) {
++    Card(modifier = Modifier.fillMaxWidth()) {
++        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
++            Text("Perfil", style = MaterialTheme.typography.titleMedium)
++            OutlinedTextField(
++                value = vm.firstName, onValueChange = { vm.firstName = it },
++                label = { Text("Nombres") }, keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next)
++            )
++            OutlinedTextField(
++                value = vm.lastName, onValueChange = { vm.lastName = it },
++                label = { Text("Apellidos") })
++            OutlinedTextField(
++                value = vm.phone, onValueChange = { vm.phone = it },
++                label = { Text("Teléfono") }, keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone)
++            )
++        }
++    }
++}
++
++@Composable
++private fun SeguridadStep(vm: OnboardingViewModel) {
++    Card(modifier = Modifier.fillMaxWidth()) {
++        Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
++            Text("Seguridad", style = MaterialTheme.typography.titleMedium)
++            OutlinedTextField(
++                value = vm.username, onValueChange = { vm.username = it },
++                label = { Text("Usuario/Alias") }, keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next)
++            )
++            OutlinedTextField(
++                value = vm.password, onValueChange = { vm.password = it },
++                label = { Text("Contraseña") }
++            )
++        }
++    }
++}
++
++@Composable
++private fun FotoStep(vm: OnboardingViewModel) {
++    val launcher = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
++        vm.photoUri = uri?.toString()
++    }
++    Card(modifier = Modifier.fillMaxWidth()) {
++        Column(Modifier.padding(16	dp), verticalArrangement = Arrangement.spacedBy(12	dp)) {
++            Text("Foto", style = MaterialTheme.typography.titleMedium)
++            Button(onClick = { launcher.launch("image/*") }) { Text("Seleccionar foto") }
++            vm.photoUri?.let { src ->
++                Image(
++                    painter = rememberAsyncImagePainter(model = src),
++                    contentDescription = "preview",
++                    modifier = Modifier
++                        .fillMaxWidth()
++                        .height(180.dp),
++                    contentScale = ContentScale.Crop
++                )
++            }
++        }
++    }
++}
+*** End Patch
+*** Begin Patch
+*** Add File: app/src/main/java/com/deercom/testo11/ui/screens/onboarding/SummaryScreen.kt
++package com.deercom.testo11.ui.screens.onboarding
++
++import androidx.compose.foundation.Image
++import androidx.compose.foundation.layout.Arrangement
++import androidx.compose.foundation.layout.Column
++import androidx.compose.foundation.layout.Row
++import androidx.compose.foundation.layout.Spacer
++import androidx.compose.foundation.layout.fillMaxSize
++import androidx.compose.foundation.layout.fillMaxWidth
++import androidx.compose.foundation.layout.height
++import androidx.compose.foundation.layout.padding
++import androidx.compose.material3.Button
++import androidx.compose.material3.Card
++import androidx.compose.material3.MaterialTheme
++import androidx.compose.material3.Text
++import androidx.compose.runtime.Composable
++import androidx.compose.ui.Alignment
++import androidx.compose.ui.Modifier
++import androidx.compose.ui.layout.ContentScale
++import androidx.compose.ui.unit.dp
++import coil.compose.rememberAsyncImagePainter
++import com.deercom.testo11.onboarding.OnboardingViewModel
++import com.deercom.testo11.ui.screens.components.AppScaffold
++import com.deercom.testo11.ui.screens.components.AppTopBar
++
++@Composable
++fun SummaryScreen(
++    vm: OnboardingViewModel,
++    onEditSection: (OnboardingViewModel.Section) -> Unit,
++    onConfirm: () -> Unit
++) {
++    AppScaffold(topBar = {
++        AppTopBar(title = "Resumen", actions = { com.deercom.testo11.ui.screens.components.TopBarOverflow() })
++    }) { pad ->
++        Column(
++            modifier = Modifier
++                .fillMaxSize()
++                .padding(pad)
++                .padding(16.dp),
++            verticalArrangement = Arrangement.spacedBy(16.dp)
++        ) {
++            Card(Modifier.fillMaxWidth()) {
++                Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
++                    Text("Empresa", style = MaterialTheme.typography.titleMedium)
++                    Text("Nombre: ${vm.companyName}")
++                    Text("RUC/ID: ${vm.companyId}")
++                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
++                        Button(onClick = { onEditSection(OnboardingViewModel.Section.EMPRESA) }) { Text("Editar") }
++                    }
++                }
++            }
++            Card(Modifier.fillMaxWidth()) {
++                Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
++                    Text("Perfil", style = MaterialTheme.typography.titleMedium)
++                    Text("Nombre: ${vm.firstName} ${vm.lastName}")
++                    Text("Teléfono: ${vm.phone}")
++                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
++                        Button(onClick = { onEditSection(OnboardingViewModel.Section.PERFIL) }) { Text("Editar") }
++                    }
++                }
++            }
++            Card(Modifier.fillMaxWidth()) {
++                Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
++                    Text("Seguridad", style = MaterialTheme.typography.titleMedium)
++                    Text("Usuario: ${vm.username}")
++                    Row(horizontalArrangement = Arrangement.spacedBy(8	dp)) {
++                        Button(onClick = { onEditSection(OnboardingViewModel.Section.SEGURIDAD) }) { Text("Editar") }
++                    }
++                }
++            }
++            Card(Modifier.fillMaxWidth()) {
++                Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8	dp)) {
++                    Text("Foto", style = MaterialTheme.typography.titleMedium)
++                    vm.photoUri?.let { src ->
++                        Image(
++                            painter = rememberAsyncImagePainter(model = src),
++                            contentDescription = "preview",
++                            modifier = Modifier
++                                .fillMaxWidth()
++                                .height(180	dp),
++                            contentScale = ContentScale.Crop
++                        )
++                    }
++                    Row(horizontalArrangement = Arrangement.spacedBy(8	dp)) {
++                        Button(onClick = { onEditSection(OnboardingViewModel.Section.FOTO) }) { Text("Editar") }
++                    }
++                }
++            }
++            Spacer(Modifier.height(8.dp))
++            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12	dp)) {
++                Button(onClick = { vm.saveAll(onConfirm) }) { Text("Confirmar y guardar") }
++            }
++        }
++    }
++}
++
+*** End Patch

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Testo11
+
+Aplicación Android con **Jetpack Compose (Material 3)**, **Hilt** para DI y **DataStore** (Preferences) para persistencia local. Flujo pensado para un entorno empresarial donde un **Admin Master** crea la empresa y el primer usuario.
+
+## Flujo (resumen)
+1. **StartRouter**: si no hay empresa o alias → va al **Wizard**; si existen → va a **LoginAlias**.  
+2. **Wizard**:  
+   - **CreateCompany**: guarda *companyId* y *companyName*.  
+   - **CreateAdminUser**: guarda el **alias** del Admin Master.  
+   - **ProfileCard**: datos básicos del usuario (nombre/teléfono/documento).  
+3. **LoginAlias**: valida el alias (se prellena desde DataStore).  
+4. **Home**: muestra `companyName` y `alias`. “Cerrar sesión” borra **solo el alias** (empresa/perfil permanecen).
+
+## Stack técnico
+- Jetpack **Compose** (Material 3) + **Navigation Compose**
+- **Hilt** (KSP) para inyección de dependencias
+- **DataStore (Preferences)** para sesión/perfil
+- Kotlin **17**, Gradle **8.7**, Android Gradle Plugin **8.3.2**, `compileSdk` **34`
+
+## Estructura (simplificada)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,6 +55,10 @@ dependencies {
     implementation("androidx.compose.ui:ui-tooling-preview")
     debugImplementation("androidx.compose.ui:ui-tooling")
 
+    // Navegación Compose
+    implementation("androidx.navigation:navigation-compose:2.7.7")
+
+
     // Hilt (puedes dejar 2.51.1, es compatible)
     implementation("com.google.dagger:hilt-android:2.51.1")
     ksp("com.google.dagger:hilt-compiler:2.51.1")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,6 +60,10 @@ dependencies {
 
     implementation("androidx.datastore:datastore-preferences:1.1.1")
 
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.7.0")
+
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
+
 
 
     // Hilt (puedes dejar 2.51.1, es compatible)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,6 +58,9 @@ dependencies {
     // Navegación Compose
     implementation("androidx.navigation:navigation-compose:2.7.7")
 
+    implementation("androidx.datastore:datastore-preferences:1.1.1")
+
+
 
     // Hilt (puedes dejar 2.51.1, es compatible)
     implementation("com.google.dagger:hilt-android:2.51.1")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,6 +65,8 @@ dependencies {
     // Hilt (puedes dejar 2.51.1, es compatible)
     implementation("com.google.dagger:hilt-android:2.51.1")
     ksp("com.google.dagger:hilt-compiler:2.51.1")
+    implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
+
 }
 
 // Kotlin 17

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.Material3.DayNight.NoActionBar">
+        android:theme="@style/Theme.Testo11">
         <activity android:name=".MainActivity"
             android:exported="true">
             <intent-filter>

--- a/app/src/main/java/com/deercom/testo11/MainActivity.kt
+++ b/app/src/main/java/com/deercom/testo11/MainActivity.kt
@@ -1,29 +1,38 @@
-
 package com.deercom.testo11
+
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.*
-import androidx.compose.material3.*
-import androidx.compose.material3.TopAppBar
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
+import androidx.navigation.compose.rememberNavController
+import dagger.hilt.android.AndroidEntryPoint
+import com.deercom.testo11.nav.AppNavGraph
 
+@AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContent { AppTheme { HelloScreen() } }
+        enableEdgeToEdge()
+        setContent { MainApp() }
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun HelloScreen() {
-    Scaffold(topBar = { TopAppBar(title = { Text("Testo11") }) }) { inner ->
-        Box(Modifier.padding(inner).fillMaxSize(), contentAlignment = Alignment.Center) {
-            Text("Hello Testo11")
+private fun MainApp() {
+    MaterialTheme {
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = MaterialTheme.colorScheme.background
+        ) {
+            val nav = rememberNavController()
+            AppNavGraph(nav)
         }
     }
 }

--- a/app/src/main/java/com/deercom/testo11/Theme.kt
+++ b/app/src/main/java/com/deercom/testo11/Theme.kt
@@ -1,19 +1,92 @@
-
 package com.deercom.testo11
-import androidx.compose.material3.*
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.graphics.Color
 
-private val Dark = darkColorScheme(
-    primary = Color(0xFF0B3D91),
-    secondary = Color(0xFF2E3A59),
-    background = Color(0xFF0F172A),
-    surface = Color(0xFF111827),
-    onPrimary = Color.White,
-    onSecondary = Color.White,
-    onBackground = Color(0xFFE5E7EB),
-    onSurface = Color(0xFFE5E7EB),
+// Paleta sobria (azul/gris)
+private val Primary = Color(0xFF1E3A8A)  // azul profundo
+private val OnPrimary = Color(0xFFFFFFFF)
+private val Secondary = Color(0xFF334155) // gris azulado
+private val OnSecondary = Color(0xFFE2E8F0)
+private val BackgroundLight = Color(0xFFF8FAFC)
+private val SurfaceLight = Color(0xFFFFFFFF)
+private val TextPrimaryLight = Color(0xFF0F172A) // slate-900
+private val OutlineLight = Color(0xFFCBD5E1)
+
+private val BackgroundDark = Color(0xFF0B1220)
+private val SurfaceDark = Color(0xFF0F172A)
+private val TextPrimaryDark = Color(0xFFE5E7EB) // slate-200
+private val OutlineDark = Color(0xFF334155)
+
+private val LightColors: ColorScheme = lightColorScheme(
+    primary = Primary,
+    onPrimary = OnPrimary,
+    secondary = Secondary,
+    onSecondary = OnSecondary,
+    background = BackgroundLight,
+    surface = SurfaceLight,
+    onSurface = TextPrimaryLight,
+    outline = OutlineLight
+)
+
+private val DarkColors: ColorScheme = darkColorScheme(
+    primary = Primary,
+    onPrimary = OnPrimary,
+    secondary = Secondary,
+    onSecondary = OnSecondary,
+    background = BackgroundDark,
+    surface = SurfaceDark,
+    onSurface = TextPrimaryDark,
+    outline = OutlineDark
+)
+
+// Tipografía clara y profesional
+private val AppTypography = Typography(
+    titleLarge = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 22.sp
+    ),
+    titleMedium = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Medium,
+        fontSize = 18.sp
+    ),
+    bodyLarge = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Normal,
+        fontSize = 16.sp
+    ),
+    bodyMedium = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Normal,
+        fontSize = 14.sp
+    ),
+    labelLarge = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Medium,
+        fontSize = 14.sp
+    )
 )
 
 @Composable
-fun AppTheme(content:@Composable ()->Unit) { MaterialTheme(colorScheme = Dark, content = content) }
+fun AppTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit
+) {
+    MaterialTheme(
+        colorScheme = if (darkTheme) DarkColors else LightColors,
+        typography = AppTypography,
+        content = content
+    )
+}

--- a/app/src/main/java/com/deercom/testo11/auth/AuthViewModel.kt
+++ b/app/src/main/java/com/deercom/testo11/auth/AuthViewModel.kt
@@ -1,0 +1,28 @@
+package com.deercom.testo11.auth
+
+import androidx.lifecycle.ViewModel
+import com.deercom.testo11.data.SessionStore
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+
+@HiltViewModel
+class AuthViewModel @Inject constructor(
+    private val session: SessionStore
+) : ViewModel() {
+
+    /** Alias guardado en DataStore (flujo para observar desde UI). */
+    val aliasFlow: Flow<String> = session.aliasFlow
+
+    /** Valida que el alias ingresado coincida con el alias guardado. */
+    suspend fun isAliasValid(input: String): Boolean {
+        val saved = session.aliasFlow.first()
+        return saved.isNotBlank() && input.equals(saved, ignoreCase = true)
+    }
+
+    /** Limpia la sesión. */
+    suspend fun logout() {
+        session.clear()
+    }
+}

--- a/app/src/main/java/com/deercom/testo11/auth/AuthViewModel.kt
+++ b/app/src/main/java/com/deercom/testo11/auth/AuthViewModel.kt
@@ -12,17 +12,14 @@ class AuthViewModel @Inject constructor(
     private val session: SessionStore
 ) : ViewModel() {
 
-    /** Alias guardado en DataStore (flujo para observar desde UI). */
+    /** Alias guardado en DataStore (para prellenar Login). */
     val aliasFlow: Flow<String> = session.aliasFlow
 
-    /** Valida que el alias ingresado coincida con el alias guardado. */
+    /** Valida que el alias ingresado coincida con lo guardado. */
     suspend fun isAliasValid(input: String): Boolean {
         val saved = session.aliasFlow.first()
         return saved.isNotBlank() && input.equals(saved, ignoreCase = true)
     }
 
-    /** Limpia la sesión. */
-    suspend fun logout() {
-        session.clear()
-    }
+    // Nota: logout lo gestiona HomeViewModel con session.clearSessionOnly()
 }

--- a/app/src/main/java/com/deercom/testo11/data/LocalUserRepository.kt
+++ b/app/src/main/java/com/deercom/testo11/data/LocalUserRepository.kt
@@ -1,78 +1,37 @@
-package com.deercom.testo11.data
+@@
+ package com.deercom.testo11.data
+ 
+ import android.content.Context
+ import androidx.datastore.preferences.core.Preferences
+ import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.booleanPreferencesKey
+ import androidx.datastore.preferences.core.stringPreferencesKey
+ import androidx.datastore.preferences.preferencesDataStore
+ import dagger.hilt.android.qualifiers.ApplicationContext
+ import kotlinx.coroutines.flow.Flow
+ import kotlinx.coroutines.flow.map
+@@
+ private val Context.userPrefs by preferencesDataStore("users_prefs")
+ 
+ class LocalUserRepository @Inject constructor(
+     @ApplicationContext private val context: Context
+ ) {
+     private object K {
+         val USERS: Preferences.Key<String> = stringPreferencesKey("users_json")
+        val SETUP_DONE: Preferences.Key<Boolean> = booleanPreferencesKey("setup_done")
+     }
+@@
+     suspend fun addUser(u: User) {
+         val current = users()
+         val updated = current + u
+         context.userPrefs.edit { it[K.USERS] = toJson(updated) }
+     }
 
-import android.content.Context
-import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.stringSetPreferencesKey
-import androidx.datastore.preferences.preferencesDataStore
-import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
-import java.security.MessageDigest
-import javax.inject.Inject
-import javax.inject.Singleton
+    // --- PR #1: bandera de configuración inicial completada
+    fun isSetupDone(): Flow<Boolean> =
+        context.userPrefs.data.map { it[K.SETUP_DONE] ?: false }
 
-private val Context.ds by preferencesDataStore(name = "local_users")
-
-@Singleton
-class LocalUserRepository @Inject constructor(
-    @ApplicationContext private val context: Context
-) {
-    private object K {
-        val USERS: Preferences.Key<Set<String>> = stringSetPreferencesKey("users_set")
-        val CARGOS: Preferences.Key<Set<String>> = stringSetPreferencesKey("cargos_set")
-        val LOCALIDADES: Preferences.Key<Set<String>> = stringSetPreferencesKey("localidades_set")
+    suspend fun setSetupDone(value: Boolean) {
+        context.userPrefs.edit { it[K.SETUP_DONE] = value }
     }
-
-    // -------- Encoding simple (sin libs externas) --------
-    private fun encode(user: User): String =
-        listOf(
-            user.alias, user.nombres, user.apellidos, user.cargo, user.documento,
-            user.telefonoPersonal, user.telefonoDispositivo, user.localidad, user.fotoUri, user.passwordHash
-        ).joinToString(separator = "§") // separador poco común
-
-    private fun decode(s: String): User {
-        val parts = s.split("§")
-        return User(
-            alias = parts.getOrNull(0) ?: "",
-            nombres = parts.getOrNull(1) ?: "",
-            apellidos = parts.getOrNull(2) ?: "",
-            cargo = parts.getOrNull(3) ?: "",
-            documento = parts.getOrNull(4) ?: "",
-            telefonoPersonal = parts.getOrNull(5) ?: "",
-            telefonoDispositivo = parts.getOrNull(6) ?: "",
-            localidad = parts.getOrNull(7) ?: "",
-            fotoUri = parts.getOrNull(8) ?: "",
-            passwordHash = parts.getOrNull(9) ?: ""
-        )
-    }
-
-    fun usersFlow(): Flow<List<User>> =
-        context.ds.data.map { it[K.USERS].orEmpty().map(::decode) }
-
-    suspend fun upsertUser(u: User) {
-        context.ds.edit { prefs ->
-            val all = prefs[K.USERS].orEmpty().toMutableSet()
-            // remove old with same alias
-            val without = all.filterNot { decode(it).alias.equals(u.alias, ignoreCase = true) }.toMutableSet()
-            without.add(encode(u))
-            prefs[K.USERS] = without
-            if (u.cargo.isNotBlank()) prefs[K.CARGOS] = prefs[K.CARGOS].orEmpty() + u.cargo
-            if (u.localidad.isNotBlank()) prefs[K.LOCALIDADES] = prefs[K.LOCALIDADES].orEmpty() + u.localidad
-        }
-    }
-
-    fun cargosFlow(): Flow<List<String>> =
-        context.ds.data.map { it[K.CARGOS].orEmpty().sorted() }
-
-    fun localidadesFlow(): Flow<List<String>> =
-        context.ds.data.map { it[K.LOCALIDADES].orEmpty().sorted() }
-
-    // Hash simple (modo pruebas) con SHA-256
-    fun sha256(text: String): String {
-        val md = MessageDigest.getInstance("SHA-256")
-        val bytes = md.digest(text.toByteArray(Charsets.UTF_8))
-        return bytes.joinToString("") { "%02x".format(it) }
-    }
-}
-
+ }

--- a/app/src/main/java/com/deercom/testo11/data/LocalUserRepository.kt
+++ b/app/src/main/java/com/deercom/testo11/data/LocalUserRepository.kt
@@ -1,0 +1,78 @@
+package com.deercom.testo11.data
+
+import android.content.Context
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import java.security.MessageDigest
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val Context.ds by preferencesDataStore(name = "local_users")
+
+@Singleton
+class LocalUserRepository @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private object K {
+        val USERS: Preferences.Key<Set<String>> = stringSetPreferencesKey("users_set")
+        val CARGOS: Preferences.Key<Set<String>> = stringSetPreferencesKey("cargos_set")
+        val LOCALIDADES: Preferences.Key<Set<String>> = stringSetPreferencesKey("localidades_set")
+    }
+
+    // -------- Encoding simple (sin libs externas) --------
+    private fun encode(user: User): String =
+        listOf(
+            user.alias, user.nombres, user.apellidos, user.cargo, user.documento,
+            user.telefonoPersonal, user.telefonoDispositivo, user.localidad, user.fotoUri, user.passwordHash
+        ).joinToString(separator = "§") // separador poco común
+
+    private fun decode(s: String): User {
+        val parts = s.split("§")
+        return User(
+            alias = parts.getOrNull(0) ?: "",
+            nombres = parts.getOrNull(1) ?: "",
+            apellidos = parts.getOrNull(2) ?: "",
+            cargo = parts.getOrNull(3) ?: "",
+            documento = parts.getOrNull(4) ?: "",
+            telefonoPersonal = parts.getOrNull(5) ?: "",
+            telefonoDispositivo = parts.getOrNull(6) ?: "",
+            localidad = parts.getOrNull(7) ?: "",
+            fotoUri = parts.getOrNull(8) ?: "",
+            passwordHash = parts.getOrNull(9) ?: ""
+        )
+    }
+
+    fun usersFlow(): Flow<List<User>> =
+        context.ds.data.map { it[K.USERS].orEmpty().map(::decode) }
+
+    suspend fun upsertUser(u: User) {
+        context.ds.edit { prefs ->
+            val all = prefs[K.USERS].orEmpty().toMutableSet()
+            // remove old with same alias
+            val without = all.filterNot { decode(it).alias.equals(u.alias, ignoreCase = true) }.toMutableSet()
+            without.add(encode(u))
+            prefs[K.USERS] = without
+            if (u.cargo.isNotBlank()) prefs[K.CARGOS] = prefs[K.CARGOS].orEmpty() + u.cargo
+            if (u.localidad.isNotBlank()) prefs[K.LOCALIDADES] = prefs[K.LOCALIDADES].orEmpty() + u.localidad
+        }
+    }
+
+    fun cargosFlow(): Flow<List<String>> =
+        context.ds.data.map { it[K.CARGOS].orEmpty().sorted() }
+
+    fun localidadesFlow(): Flow<List<String>> =
+        context.ds.data.map { it[K.LOCALIDADES].orEmpty().sorted() }
+
+    // Hash simple (modo pruebas) con SHA-256
+    fun sha256(text: String): String {
+        val md = MessageDigest.getInstance("SHA-256")
+        val bytes = md.digest(text.toByteArray(Charsets.UTF_8))
+        return bytes.joinToString("") { "%02x".format(it) }
+    }
+}
+

--- a/app/src/main/java/com/deercom/testo11/data/Models.kt
+++ b/app/src/main/java/com/deercom/testo11/data/Models.kt
@@ -1,0 +1,15 @@
+package com.deercom.testo11.data
+
+data class User(
+    val alias: String = "",
+    val nombres: String = "",
+    val apellidos: String = "",
+    val cargo: String = "",
+    val documento: String = "",
+    val telefonoPersonal: String = "",
+    val telefonoDispositivo: String = "",
+    val localidad: String = "",
+    val fotoUri: String = "",
+    val passwordHash: String = "" // modo pruebas: hash simple (SHA-256)
+)
+

--- a/app/src/main/java/com/deercom/testo11/data/SessionStore.kt
+++ b/app/src/main/java/com/deercom/testo11/data/SessionStore.kt
@@ -14,13 +14,30 @@ class SessionStore @Inject constructor(
 ) {
     private val KEY_ALIAS = stringPreferencesKey("alias")
     private val KEY_COMPANY = stringPreferencesKey("company_id")
+    private val KEY_COMPANY_NAME = stringPreferencesKey("company_name")
+    private val KEY_PROFILE_NAME = stringPreferencesKey("profile_name")
+    private val KEY_PROFILE_PHONE = stringPreferencesKey("profile_phone")
+    private val KEY_PROFILE_DOCID = stringPreferencesKey("profile_docid")
 
     val aliasFlow = ds.data.map { it[KEY_ALIAS].orEmpty() }
     val companyIdFlow = ds.data.map { it[KEY_COMPANY].orEmpty() }
+    val companyNameFlow = ds.data.map { it[KEY_COMPANY_NAME].orEmpty() }
+    val profileNameFlow = ds.data.map { it[KEY_PROFILE_NAME].orEmpty() }
+    val profilePhoneFlow = ds.data.map { it[KEY_PROFILE_PHONE].orEmpty() }
+    val profileDocIdFlow = ds.data.map { it[KEY_PROFILE_DOCID].orEmpty() }
 
-    suspend fun setAlias(v: String) = ds.edit { it[KEY_ALIAS] = v }
-    suspend fun setCompanyId(v: String) = ds.edit { it[KEY_COMPANY] = v }
-    suspend fun clear() = ds.edit { it.clear() }
+    suspend fun setAlias(alias: String) = ds.edit { it[KEY_ALIAS] = alias }
+    suspend fun setCompanyId(id: String) = ds.edit { it[KEY_COMPANY] = id }
+    suspend fun setCompanyName(name: String) = ds.edit { it[KEY_COMPANY_NAME] = name }
+    suspend fun setProfile(name: String, phone: String, docId: String) = ds.edit {
+        it[KEY_PROFILE_NAME] = name
+        it[KEY_PROFILE_PHONE] = phone
+        it[KEY_PROFILE_DOCID] = docId
+    }
+
+    /** Cerrar sesión SIN borrar datos de empresa/perfil */
+    suspend fun clearSessionOnly() = ds.edit { it.remove(KEY_ALIAS) }
+
+    /** Borrar todo (útil para “reset app”) */
+    suspend fun clearAll() = ds.edit { it.clear() }
 }
-
-

--- a/app/src/main/java/com/deercom/testo11/data/SessionStore.kt
+++ b/app/src/main/java/com/deercom/testo11/data/SessionStore.kt
@@ -1,0 +1,26 @@
+package com.deercom.testo11.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SessionStore @Inject constructor(
+    private val ds: DataStore<Preferences>
+) {
+    private val KEY_ALIAS = stringPreferencesKey("alias")
+    private val KEY_COMPANY = stringPreferencesKey("company_id")
+
+    val aliasFlow = ds.data.map { it[KEY_ALIAS].orEmpty() }
+    val companyIdFlow = ds.data.map { it[KEY_COMPANY].orEmpty() }
+
+    suspend fun setAlias(v: String) = ds.edit { it[KEY_ALIAS] = v }
+    suspend fun setCompanyId(v: String) = ds.edit { it[KEY_COMPANY] = v }
+    suspend fun clear() = ds.edit { it.clear() }
+}
+
+

--- a/app/src/main/java/com/deercom/testo11/di/AppModule.kt
+++ b/app/src/main/java/com/deercom/testo11/di/AppModule.kt
@@ -1,0 +1,23 @@
+package com.deercom.testo11.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.preferencesDataStoreFile
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AppModule {
+    @Provides @Singleton
+    fun provideDataStore(@ApplicationContext ctx: Context): DataStore<Preferences> =
+        PreferenceDataStoreFactory.create { ctx.preferencesDataStoreFile("app_prefs") }
+}
+
+

--- a/app/src/main/java/com/deercom/testo11/di/AppModule.kt
+++ b/app/src/main/java/com/deercom/testo11/di/AppModule.kt
@@ -15,7 +15,8 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object AppModule {
-    @Provides @Singleton
+    @Provides
+    @Singleton
     fun provideDataStore(@ApplicationContext ctx: Context): DataStore<Preferences> =
         PreferenceDataStoreFactory.create { ctx.preferencesDataStoreFile("app_prefs") }
 }

--- a/app/src/main/java/com/deercom/testo11/home/HomeViewModel.kt
+++ b/app/src/main/java/com/deercom/testo11/home/HomeViewModel.kt
@@ -1,2 +1,29 @@
 package com.deercom.testo11.home
 
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.deercom.testo11.data.SessionStore
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class HomeViewModel @Inject constructor(
+    private val session: SessionStore
+) : ViewModel() {
+
+    val companyName = session.companyNameFlow
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), "")
+
+    val alias = session.aliasFlow
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), "")
+
+    fun logout(onDone: () -> Unit) {
+        viewModelScope.launch {
+            session.clearSessionOnly() // <- NO usar .clear()
+            onDone()
+        }
+    }
+}

--- a/app/src/main/java/com/deercom/testo11/home/HomeViewModel.kt
+++ b/app/src/main/java/com/deercom/testo11/home/HomeViewModel.kt
@@ -1,0 +1,2 @@
+package com.deercom.testo11.home
+

--- a/app/src/main/java/com/deercom/testo11/login/LoginUserPassScreen.kt
+++ b/app/src/main/java/com/deercom/testo11/login/LoginUserPassScreen.kt
@@ -1,0 +1,50 @@
+package com.deercom.testo11.login
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.automirrored.filled.Login
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import com.deercom.testo11.ui.screens.components.AppScaffold
+import com.deercom.testo11.ui.screens.components.AppTopBar
+
+@Composable
+fun LoginUserPassScreen(
+    onSuccess: () -> Unit,
+    onBack: () -> Unit
+) {
+    var alias by remember { mutableStateOf("") }
+    var pass by remember { mutableStateOf("") }
+
+    AppScaffold(
+        topBar = { AppTopBar(title = "Iniciar sesión") }
+    ) { pad ->
+        Column(
+            modifier = Modifier
+                .padding(pad)
+                .padding(16.dp)
+                .fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            OutlinedTextField(
+                value = alias, onValueChange = { alias = it },
+                label = { Text("Usuario") },
+                leadingIcon = { Icon(Icons.AutoMirrored.Filled.Login, null) },
+                singleLine = true, modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = pass, onValueChange = { pass = it },
+                label = { Text("Contraseña") },
+                visualTransformation = PasswordVisualTransformation(),
+                singleLine = true, modifier = Modifier.fillMaxWidth()
+            )
+            Button(
+                onClick = { onSuccess() }, // modo pruebas
+                enabled = alias.isNotBlank()
+            ) { Text("Entrar") }
+        }
+    }
+}
+

--- a/app/src/main/java/com/deercom/testo11/nav/AppNavGraph.kt
+++ b/app/src/main/java/com/deercom/testo11/nav/AppNavGraph.kt
@@ -1,0 +1,21 @@
+package com.deercom.testo11.nav
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.NavHostController
+import com.deercom.testo11.ui.screens.*
+
+@Composable
+fun AppNavGraph(nav: NavHostController) {
+    NavHost(navController = nav, startDestination = Route.WizardStart.path) {
+        composable(Route.WizardStart.path)     { WizardStartScreen(onNext = { nav.navigate(Route.CreateCompany.path) }) }
+        composable(Route.CreateCompany.path)   { CreateCompanyScreen(onNext = { nav.navigate(Route.CreateAdminUser.path) }, onBack = { nav.popBackStack() }) }
+        composable(Route.CreateAdminUser.path) { CreateAdminUserScreen(onNext = { nav.navigate(Route.ProfileCard.path) }, onBack = { nav.popBackStack() }) }
+        composable(Route.ProfileCard.path)     { ProfileCardScreen(onNext = { nav.navigate(Route.LoginAlias.path) }, onBack = { nav.popBackStack() }) }
+        composable(Route.LoginAlias.path)      { LoginAliasScreen(onSuccess = { nav.navigate(Route.Home.path) }, onBack = { nav.popBackStack() }) }
+        composable(Route.Home.path)            { HomeScreen(onLogout = { nav.navigate(Route.LoginAlias.path) { popUpTo(0) } }) }
+    }
+}
+
+

--- a/app/src/main/java/com/deercom/testo11/nav/AppNavGraph.kt
+++ b/app/src/main/java/com/deercom/testo11/nav/AppNavGraph.kt
@@ -1,14 +1,20 @@
 package com.deercom.testo11.nav
 
 import androidx.compose.runtime.Composable
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import androidx.navigation.NavHostController
 import com.deercom.testo11.ui.screens.*
 
 @Composable
 fun AppNavGraph(nav: NavHostController) {
-    NavHost(navController = nav, startDestination = Route.WizardStart.path) {
+    NavHost(navController = nav, startDestination = Route.StartRouter.path) {
+        composable(Route.StartRouter.path) {
+            StartRouterScreen(
+                goWizard = { nav.navigate(Route.WizardStart.path) { popUpTo(0) } },
+                goLogin  = { nav.navigate(Route.LoginAlias.path) { popUpTo(0) } }
+            )
+        }
         composable(Route.WizardStart.path)     { WizardStartScreen(onNext = { nav.navigate(Route.CreateCompany.path) }) }
         composable(Route.CreateCompany.path)   { CreateCompanyScreen(onNext = { nav.navigate(Route.CreateAdminUser.path) }, onBack = { nav.popBackStack() }) }
         composable(Route.CreateAdminUser.path) { CreateAdminUserScreen(onNext = { nav.navigate(Route.ProfileCard.path) }, onBack = { nav.popBackStack() }) }
@@ -17,5 +23,3 @@ fun AppNavGraph(nav: NavHostController) {
         composable(Route.Home.path)            { HomeScreen(onLogout = { nav.navigate(Route.LoginAlias.path) { popUpTo(0) } }) }
     }
 }
-
-

--- a/app/src/main/java/com/deercom/testo11/nav/NewAppNavGraph.kt
+++ b/app/src/main/java/com/deercom/testo11/nav/NewAppNavGraph.kt
@@ -1,48 +1,58 @@
-package com.deercom.testo11.nav
-
-import androidx.compose.runtime.Composable
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.rememberNavController
-import com.deercom.testo11.login.LoginUserPassScreen
-import com.deercom.testo11.ui.screens.home.HomeWithBottomBarScreen
+@@
+ package com.deercom.testo11.nav
+ 
+ import androidx.compose.runtime.Composable
+ import androidx.navigation.compose.NavHost
+ import androidx.navigation.compose.composable
+ import androidx.navigation.compose.rememberNavController
+import androidx.compose.runtime.LaunchedEffect
+import androidx.hilt.navigation.compose.hiltViewModel
+import kotlinx.coroutines.flow.first
+import com.deercom.testo11.onboarding.OnboardingViewModel
 import com.deercom.testo11.ui.screens.onboarding.OnboardingScreen
-
-@Composable
-fun NewAppNavGraph() {
-    val nav = rememberNavController()
-    NavHost(navController = nav, startDestination = NewRoutes.ONBOARDING) {
-        // Alta unificada
-        composable(NewRoutes.ONBOARDING) {
+import com.deercom.testo11.login.LoginUserPassScreen
+import com.deercom.testo11.ui.screens.home.HomeScreen as HomeWithBottomBarScreen /* ajusta si tu Home se llama distinto */
+ 
+ @Composable
+ fun NewAppNavGraph() {
+     val nav = rememberNavController()
+-    NavHost(navController = nav, startDestination = NewRoutes.Onboarding.route) {
+    // PR #1: Iniciamos en Start y redirigimos según setup_done
+    NavHost(navController = nav, startDestination = NewRoutes.Start.route) {
+        composable(NewRoutes.Start.route) {
+            val vm: OnboardingViewModel = hiltViewModel()
+            LaunchedEffect(Unit) {
+                val done = vm.setupDoneFlow().first()
+                if (done) {
+                    nav.navigate(NewRoutes.Login.route) { popUpTo(0) }
+                } else {
+                    nav.navigate(NewRoutes.Onboarding.route) { popUpTo(0) }
+                }
+            }
+        }
+         composable(NewRoutes.Onboarding.route) {
+-            com.deercom.testo11.ui.screens.onboarding.OnboardingScreen(
+-                onFinished = { nav.navigate(NewRoutes.Login.route) { popUpTo(0) } }
+-            )
+            val vm: OnboardingViewModel = hiltViewModel()
             OnboardingScreen(
-                onFinishFirstTime = {
-                    nav.navigate(NewRoutes.LOGIN_USER_PASS) {
-                        popUpTo(NewRoutes.ONBOARDING) { inclusive = true }
-                    }
-                },
-                onFinishFromHome = { nav.popBackStack() }
-            )
-        }
-        // Login usuario + contraseña (modo pruebas)
-        composable(NewRoutes.LOGIN_USER_PASS) {
-            LoginUserPassScreen(
-                onSuccess = {
-                    nav.navigate(NewRoutes.HOME) {
-                        popUpTo(NewRoutes.LOGIN_USER_PASS) { inclusive = true }
-                    }
-                },
-                onBack = { nav.popBackStack() }
-            )
-        }
-        // Home con bottom bar (Usuarios por defecto)
-        composable(NewRoutes.HOME) {
-            HomeWithBottomBarScreen(
-                onEditUser = {
-                    // Abrir Onboarding para "editar" (modo pruebas: reusamos la misma pantalla)
-                    nav.navigate(NewRoutes.ONBOARDING)
+                onFinished = {
+                    vm.markSetupDone()
+                    nav.navigate(NewRoutes.Login.route) { popUpTo(0) }
                 }
             )
-        }
-    }
-}
-
+         }
+         composable(NewRoutes.Login.route) {
+-            com.deercom.testo11.login.LoginUserPassScreen(
+            LoginUserPassScreen(
+                 onLoginOk = { nav.navigate(NewRoutes.Home.route) { popUpTo(0) } }
+             )
+         }
+         composable(NewRoutes.Home.route) {
+-            com.deercom.testo11.ui.screens.home.HomeWithBottomBarScreen(
+            HomeWithBottomBarScreen(
+                 onEditUser = { /* futuro */ }
+             )
+         }
+     }
+ }

--- a/app/src/main/java/com/deercom/testo11/nav/NewAppNavGraph.kt
+++ b/app/src/main/java/com/deercom/testo11/nav/NewAppNavGraph.kt
@@ -1,0 +1,48 @@
+package com.deercom.testo11.nav
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.deercom.testo11.login.LoginUserPassScreen
+import com.deercom.testo11.ui.screens.home.HomeWithBottomBarScreen
+import com.deercom.testo11.ui.screens.onboarding.OnboardingScreen
+
+@Composable
+fun NewAppNavGraph() {
+    val nav = rememberNavController()
+    NavHost(navController = nav, startDestination = NewRoutes.ONBOARDING) {
+        // Alta unificada
+        composable(NewRoutes.ONBOARDING) {
+            OnboardingScreen(
+                onFinishFirstTime = {
+                    nav.navigate(NewRoutes.LOGIN_USER_PASS) {
+                        popUpTo(NewRoutes.ONBOARDING) { inclusive = true }
+                    }
+                },
+                onFinishFromHome = { nav.popBackStack() }
+            )
+        }
+        // Login usuario + contraseña (modo pruebas)
+        composable(NewRoutes.LOGIN_USER_PASS) {
+            LoginUserPassScreen(
+                onSuccess = {
+                    nav.navigate(NewRoutes.HOME) {
+                        popUpTo(NewRoutes.LOGIN_USER_PASS) { inclusive = true }
+                    }
+                },
+                onBack = { nav.popBackStack() }
+            )
+        }
+        // Home con bottom bar (Usuarios por defecto)
+        composable(NewRoutes.HOME) {
+            HomeWithBottomBarScreen(
+                onEditUser = {
+                    // Abrir Onboarding para "editar" (modo pruebas: reusamos la misma pantalla)
+                    nav.navigate(NewRoutes.ONBOARDING)
+                }
+            )
+        }
+    }
+}
+

--- a/app/src/main/java/com/deercom/testo11/nav/NewRoutes.kt
+++ b/app/src/main/java/com/deercom/testo11/nav/NewRoutes.kt
@@ -1,8 +1,9 @@
-package com.deercom.testo11.nav
-
-object NewRoutes {
-    const val ONBOARDING = "onboarding"
-    const val LOGIN_USER_PASS = "login_user_pass"
-    const val HOME = "home_new"
-}
-
+@@
+ package com.deercom.testo11.nav
+ 
+ enum class NewRoutes(val route: String) {
+    Start("start"),
+     Onboarding("onboarding"),
+     Login("login"),
+     Home("home")
+ }

--- a/app/src/main/java/com/deercom/testo11/nav/NewRoutes.kt
+++ b/app/src/main/java/com/deercom/testo11/nav/NewRoutes.kt
@@ -1,0 +1,8 @@
+package com.deercom.testo11.nav
+
+object NewRoutes {
+    const val ONBOARDING = "onboarding"
+    const val LOGIN_USER_PASS = "login_user_pass"
+    const val HOME = "home_new"
+}
+

--- a/app/src/main/java/com/deercom/testo11/nav/Routes.kt
+++ b/app/src/main/java/com/deercom/testo11/nav/Routes.kt
@@ -1,0 +1,11 @@
+package com.deercom.testo11.nav
+sealed class Route(val path: String) {
+    data object WizardStart      : Route("wizard/start")
+    data object CreateCompany    : Route("wizard/create_company")
+    data object CreateAdminUser  : Route("wizard/create_admin_user")
+    data object ProfileCard      : Route("profile/card")
+    data object LoginAlias       : Route("auth/login_alias")
+    data object Home             : Route("home")
+}
+
+

--- a/app/src/main/java/com/deercom/testo11/nav/Routes.kt
+++ b/app/src/main/java/com/deercom/testo11/nav/Routes.kt
@@ -1,11 +1,10 @@
 package com.deercom.testo11.nav
 sealed class Route(val path: String) {
-    data object WizardStart      : Route("wizard/start")
-    data object CreateCompany    : Route("wizard/create_company")
-    data object CreateAdminUser  : Route("wizard/create_admin_user")
-    data object ProfileCard      : Route("profile/card")
-    data object LoginAlias       : Route("auth/login_alias")
-    data object Home             : Route("home")
+    data object StartRouter     : Route("start/router")
+    data object WizardStart     : Route("wizard/start")
+    data object CreateCompany   : Route("wizard/create_company")
+    data object CreateAdminUser : Route("wizard/create_admin_user")
+    data object ProfileCard     : Route("profile/card")
+    data object LoginAlias      : Route("auth/login_alias")
+    data object Home            : Route("home")
 }
-
-

--- a/app/src/main/java/com/deercom/testo11/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/deercom/testo11/onboarding/OnboardingViewModel.kt
@@ -1,0 +1,74 @@
+package com.deercom.testo11.onboarding
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.deercom.testo11.data.LocalUserRepository
+import com.deercom.testo11.data.User
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import java.text.Normalizer
+import javax.inject.Inject
+
+@HiltViewModel
+class OnboardingViewModel @Inject constructor(
+    private val repo: LocalUserRepository
+) : ViewModel() {
+
+    data class UiState(
+        val empresaNombre: String = "",
+        val ruc: String = "",
+        val localidad: String = "",
+        val alias: String = "",
+        val nombres: String = "",
+        val apellidos: String = "",
+        val cargo: String = "",
+        val documento: String = "",
+        val telefonoPersonal: String = "",
+        val telefonoDispositivo: String = "",
+        val fotoUri: String = "",
+        val password: String = "",
+        val passwordConfirm: String = ""
+    )
+
+    private val _state = MutableStateFlow(UiState())
+    val state: StateFlow<UiState> = _state
+
+    fun update(transform: (UiState) -> UiState) {
+        _state.value = transform(_state.value)
+    }
+
+    fun regenerateAlias() {
+        val s = _state.value
+        val initial = s.nombres.trim().firstOrNull()?.lowercase() ?: ""
+        val apellido = s.apellidos.trim().split(" ").firstOrNull()?.lowercase().orEmpty()
+        val loc = s.localidad.trim().lowercase()
+        val base = (initial + apellido + if (loc.isNotBlank()) ".$loc" else "")
+        val normalized = Normalizer.normalize(base, Normalizer.Form.NFD)
+            .replace("\\p{InCombiningDiacriticalMarks}+".toRegex(), "")
+            .replace("[^a-z0-9._]".toRegex(), "")
+        update { it.copy(alias = normalized) }
+    }
+
+    fun save(onSaved: () -> Unit) {
+        val s = _state.value
+        viewModelScope.launch {
+            val user = User(
+                alias = s.alias.ifBlank { "usuario" },
+                nombres = s.nombres,
+                apellidos = s.apellidos,
+                cargo = s.cargo,
+                documento = s.documento,
+                telefonoPersonal = s.telefonoPersonal,
+                telefonoDispositivo = s.telefonoDispositivo,
+                localidad = s.localidad,
+                fotoUri = s.fotoUri,
+                passwordHash = repo.sha256(s.password)
+            )
+            repo.upsertUser(user)
+            onSaved()
+        }
+    }
+}
+

--- a/app/src/main/java/com/deercom/testo11/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/deercom/testo11/onboarding/OnboardingViewModel.kt
@@ -1,74 +1,43 @@
-package com.deercom.testo11.onboarding
+@@
+ package com.deercom.testo11.onboarding
+ 
+ import androidx.lifecycle.ViewModel
+ import androidx.lifecycle.viewModelScope
+ import com.deercom.testo11.data.LocalUserRepository
+ import com.deercom.testo11.data.User
+ import dagger.hilt.android.lifecycle.HiltViewModel
+ import kotlinx.coroutines.launch
+ import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+ 
+ @HiltViewModel
+ class OnboardingViewModel @Inject constructor(
+     private val repo: LocalUserRepository
+ ) : ViewModel() {
+@@
+     var photoUri: String? = null
+ 
+-    fun savePartial() { /* en PRs siguientes */ }
+    fun savePartial() { /* en PRs siguientes */ }
+ 
+-    fun saveFinal(onDone: () -> Unit) {
+    fun saveFinal(onDone: () -> Unit) {
+         viewModelScope.launch {
+             // crea usuario mínimo admin master
+             val user = User(
+                 id = username.ifBlank { "admin" },
+                 displayName = listOf(firstName, lastName).joinToString(" ").trim().ifBlank { "Admin" },
+                 phone = phone.ifBlank { null },
+                 role = "Admin Master"
+             )
+             repo.addUser(user)
+             onDone()
+         }
+     }
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import com.deercom.testo11.data.LocalUserRepository
-import com.deercom.testo11.data.User
-import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
-import java.text.Normalizer
-import javax.inject.Inject
-
-@HiltViewModel
-class OnboardingViewModel @Inject constructor(
-    private val repo: LocalUserRepository
-) : ViewModel() {
-
-    data class UiState(
-        val empresaNombre: String = "",
-        val ruc: String = "",
-        val localidad: String = "",
-        val alias: String = "",
-        val nombres: String = "",
-        val apellidos: String = "",
-        val cargo: String = "",
-        val documento: String = "",
-        val telefonoPersonal: String = "",
-        val telefonoDispositivo: String = "",
-        val fotoUri: String = "",
-        val password: String = "",
-        val passwordConfirm: String = ""
-    )
-
-    private val _state = MutableStateFlow(UiState())
-    val state: StateFlow<UiState> = _state
-
-    fun update(transform: (UiState) -> UiState) {
-        _state.value = transform(_state.value)
+    // --- PR #1: bandera de setup
+    fun markSetupDone() {
+        viewModelScope.launch { repo.setSetupDone(true) }
     }
-
-    fun regenerateAlias() {
-        val s = _state.value
-        val initial = s.nombres.trim().firstOrNull()?.lowercase() ?: ""
-        val apellido = s.apellidos.trim().split(" ").firstOrNull()?.lowercase().orEmpty()
-        val loc = s.localidad.trim().lowercase()
-        val base = (initial + apellido + if (loc.isNotBlank()) ".$loc" else "")
-        val normalized = Normalizer.normalize(base, Normalizer.Form.NFD)
-            .replace("\\p{InCombiningDiacriticalMarks}+".toRegex(), "")
-            .replace("[^a-z0-9._]".toRegex(), "")
-        update { it.copy(alias = normalized) }
-    }
-
-    fun save(onSaved: () -> Unit) {
-        val s = _state.value
-        viewModelScope.launch {
-            val user = User(
-                alias = s.alias.ifBlank { "usuario" },
-                nombres = s.nombres,
-                apellidos = s.apellidos,
-                cargo = s.cargo,
-                documento = s.documento,
-                telefonoPersonal = s.telefonoPersonal,
-                telefonoDispositivo = s.telefonoDispositivo,
-                localidad = s.localidad,
-                fotoUri = s.fotoUri,
-                passwordHash = repo.sha256(s.password)
-            )
-            repo.upsertUser(user)
-            onSaved()
-        }
-    }
-}
-
+    fun setupDoneFlow(): Flow<Boolean> = repo.isSetupDone()
+ }

--- a/app/src/main/java/com/deercom/testo11/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/deercom/testo11/profile/ProfileViewModel.kt
@@ -1,2 +1,29 @@
 package com.deercom.testo11.profile
 
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.deercom.testo11.data.SessionStore
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ProfileViewModel @Inject constructor(
+    private val session: SessionStore
+) : ViewModel() {
+
+    val name  = session.profileNameFlow .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), "")
+    val phone = session.profilePhoneFlow.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), "")
+    val docId = session.profileDocIdFlow .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), "")
+
+    fun save(name: String, phone: String, docId: String, onDone: () -> Unit) {
+        viewModelScope.launch {
+            session.setProfile(name.trim(), phone.trim(), docId.trim())
+            onDone()
+        }
+    }
+}
+
+

--- a/app/src/main/java/com/deercom/testo11/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/deercom/testo11/profile/ProfileViewModel.kt
@@ -1,0 +1,2 @@
+package com.deercom.testo11.profile
+

--- a/app/src/main/java/com/deercom/testo11/start/StartViewModel.kt
+++ b/app/src/main/java/com/deercom/testo11/start/StartViewModel.kt
@@ -1,0 +1,23 @@
+package com.deercom.testo11.start
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.deercom.testo11.data.SessionStore
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+@HiltViewModel
+class StartViewModel @Inject constructor(
+    session: SessionStore
+) : ViewModel() {
+
+    val companyName = session.companyNameFlow
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), "")
+
+    val alias = session.aliasFlow
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), "")
+}
+
+

--- a/app/src/main/java/com/deercom/testo11/ui/screens/CreateAdminUserScreen.kt
+++ b/app/src/main/java/com/deercom/testo11/ui/screens/CreateAdminUserScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.foundation.layout.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.deercom.testo11.wizard.WizardViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -32,6 +34,15 @@ fun CreateAdminUserScreen(onNext: () -> Unit, onBack: () -> Unit) {
                 OutlinedButton(onClick = onBack) { Text("Atrás") }
                 Button(onClick = onNext, enabled = alias.text.length >= 3) { Text("Guardar y continuar") }
             }
+        }
+    }
+
+    @Composable
+    fun CreateAdminUserScreen(onNext: () -> Unit, onBack: () -> Unit) {
+        val vm = hiltViewModel<WizardViewModel>()
+        // ...
+        Button(onClick = { vm.saveAdminAlias(alias.text) { onNext() } }, enabled = alias.text.length >= 3) {
+            Text("Guardar y continuar")
         }
     }
 }

--- a/app/src/main/java/com/deercom/testo11/ui/screens/CreateAdminUserScreen.kt
+++ b/app/src/main/java/com/deercom/testo11/ui/screens/CreateAdminUserScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AdminPanelSettings
 import androidx.compose.material3.Button
@@ -38,7 +39,8 @@ fun CreateAdminUserScreen(
     var alias by remember { mutableStateOf(TextFieldValue("")) }
 
     androidx.compose.material3.Scaffold(
-        topBar = { TopAppBar(title = { Text("Crear Admin Master") }) }
+        topBar = { TopAppBar(title = { Text("Crear Admin Master") }) },
+        contentWindowInsets = androidx.compose.foundation.layout.WindowInsets.safeDrawing
     ) { pad ->
         Column(
             modifier = Modifier

--- a/app/src/main/java/com/deercom/testo11/ui/screens/CreateAdminUserScreen.kt
+++ b/app/src/main/java/com/deercom/testo11/ui/screens/CreateAdminUserScreen.kt
@@ -1,33 +1,19 @@
 package com.deercom.testo11.ui.screens
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AdminPanelSettings
-import androidx.compose.material3.Button
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.deercom.testo11.ui.screens.components.AppScaffold
+import com.deercom.testo11.ui.screens.components.AppTopBar
 import com.deercom.testo11.wizard.WizardViewModel
-import androidx.compose.material3.Icon
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -38,9 +24,8 @@ fun CreateAdminUserScreen(
     val vm: WizardViewModel = hiltViewModel()
     var alias by remember { mutableStateOf(TextFieldValue("")) }
 
-    androidx.compose.material3.Scaffold(
-        topBar = { TopAppBar(title = { Text("Crear Admin Master") }) },
-        contentWindowInsets = androidx.compose.foundation.layout.WindowInsets.safeDrawing
+    AppScaffold(
+        topBar = { AppTopBar(title = "Crear Admin Master", navigationIcon = Icons.AutoMirrored.Filled.ArrowBack, onNavigate = onBack) }
     ) { pad ->
         Column(
             modifier = Modifier
@@ -66,13 +51,11 @@ fun CreateAdminUserScreen(
                         vm.saveAdminAlias(
                             alias = alias.text,
                             onSaved = onNext,
-                            onError = { /* aquí podrías mostrar un Snackbar si quieres */ }
+                            onError = { /* podrías mostrar un Snackbar si quieres */ }
                         )
                     },
                     enabled = alias.text.trim().length >= 3
-                ) {
-                    Text("Guardar y continuar")
-                }
+                ) { Text("Guardar y continuar") }
             }
 
             Spacer(Modifier.height(8.dp))

--- a/app/src/main/java/com/deercom/testo11/ui/screens/CreateAdminUserScreen.kt
+++ b/app/src/main/java/com/deercom/testo11/ui/screens/CreateAdminUserScreen.kt
@@ -1,50 +1,83 @@
 package com.deercom.testo11.ui.screens
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AdminPanelSettings
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
-import androidx.compose.runtime.*
-import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.deercom.testo11.wizard.WizardViewModel
+import androidx.compose.material3.Icon
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun CreateAdminUserScreen(onNext: () -> Unit, onBack: () -> Unit) {
-    var alias by remember { mutableStateOf(TextFieldValue()) }
-    Scaffold(topBar = { TopAppBar(title = { Text("Crear Admin Master") }) }) { pad ->
-        Column(Modifier.padding(pad).padding(16.dp)) {
+fun CreateAdminUserScreen(
+    onNext: () -> Unit,
+    onBack: () -> Unit
+) {
+    val vm: WizardViewModel = hiltViewModel()
+    var alias by remember { mutableStateOf(TextFieldValue("")) }
+
+    androidx.compose.material3.Scaffold(
+        topBar = { TopAppBar(title = { Text("Crear Admin Master") }) }
+    ) { pad ->
+        Column(
+            modifier = Modifier
+                .padding(pad)
+                .padding(16.dp)
+                .fillMaxWidth()
+        ) {
             OutlinedTextField(
-                value = alias, onValueChange = { alias = it },
+                value = alias,
+                onValueChange = { alias = it },
                 label = { Text("Alias (sin correo)") },
-                leadingIcon = { Icon(Icons.Default.AdminPanelSettings, null) }, singleLine = true, modifier = Modifier.fillMaxWidth()
+                leadingIcon = { Icon(Icons.Filled.AdminPanelSettings, contentDescription = null) },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
             )
+
             Spacer(Modifier.height(16.dp))
+
             Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                 OutlinedButton(onClick = onBack) { Text("Atrás") }
-                Button(onClick = onNext, enabled = alias.text.length >= 3) { Text("Guardar y continuar") }
+                Button(
+                    onClick = {
+                        vm.saveAdminAlias(
+                            alias = alias.text,
+                            onSaved = onNext,
+                            onError = { /* aquí podrías mostrar un Snackbar si quieres */ }
+                        )
+                    },
+                    enabled = alias.text.trim().length >= 3
+                ) {
+                    Text("Guardar y continuar")
+                }
             }
-        }
-    }
 
-    @Composable
-    fun CreateAdminUserScreen(onNext: () -> Unit, onBack: () -> Unit) {
-        val vm = hiltViewModel<WizardViewModel>()
-        // ...
-        Button(onClick = { vm.saveAdminAlias(alias.text) { onNext() } }, enabled = alias.text.length >= 3) {
-            Text("Guardar y continuar")
+            Spacer(Modifier.height(8.dp))
+            Text(
+                "Usa un alias de 3 a 20 caracteres (letras, números, _ o .).",
+                style = MaterialTheme.typography.bodySmall
+            )
         }
     }
 }
-
-

--- a/app/src/main/java/com/deercom/testo11/ui/screens/CreateAdminUserScreen.kt
+++ b/app/src/main/java/com/deercom/testo11/ui/screens/CreateAdminUserScreen.kt
@@ -1,0 +1,39 @@
+package com.deercom.testo11.ui.screens
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AdminPanelSettings
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.*
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.foundation.layout.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CreateAdminUserScreen(onNext: () -> Unit, onBack: () -> Unit) {
+    var alias by remember { mutableStateOf(TextFieldValue()) }
+    Scaffold(topBar = { TopAppBar(title = { Text("Crear Admin Master") }) }) { pad ->
+        Column(Modifier.padding(pad).padding(16.dp)) {
+            OutlinedTextField(
+                value = alias, onValueChange = { alias = it },
+                label = { Text("Alias (sin correo)") },
+                leadingIcon = { Icon(Icons.Default.AdminPanelSettings, null) }, singleLine = true, modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(Modifier.height(16.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedButton(onClick = onBack) { Text("Atrás") }
+                Button(onClick = onNext, enabled = alias.text.length >= 3) { Text("Guardar y continuar") }
+            }
+        }
+    }
+}
+
+

--- a/app/src/main/java/com/deercom/testo11/ui/screens/CreateCompanyScreen.kt
+++ b/app/src/main/java/com/deercom/testo11/ui/screens/CreateCompanyScreen.kt
@@ -1,45 +1,65 @@
 package com.deercom.testo11.ui.screens
 
+import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Domain
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.foundation.layout.*
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.deercom.testo11.wizard.WizardViewModel
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun CreateCompanyScreen(onNext: () -> Unit, onBack: () -> Unit) {
-    var name by remember { mutableStateOf(TextFieldValue()) }
+fun CreateCompanyScreen(
+    onNext: () -> Unit,
+    onBack: () -> Unit
+) {
+    val vm: WizardViewModel = hiltViewModel()
+    var name by remember { mutableStateOf(TextFieldValue("")) }
+    val snackbar = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+
     Scaffold(
-        topBar = { TopAppBar(title = { Text("Crear empresa") }) }
+        topBar = { TopAppBar(title = { Text("Crear empresa") }) },
+        snackbarHost = { SnackbarHost(snackbar) }
     ) { pad ->
-        Column(Modifier.padding(pad).padding(16.dp)) {
+        Column(
+            Modifier
+                .padding(pad)
+                .padding(16.dp)
+                .fillMaxWidth()
+        ) {
             OutlinedTextField(
-                value = name, onValueChange = { name = it },
+                value = name,
+                onValueChange = { name = it },
                 label = { Text("Nombre de la empresa") },
-                leadingIcon = { Icon(Icons.Default.Domain, null) }, singleLine = true, modifier = Modifier.fillMaxWidth()
+                leadingIcon = { Icon(Icons.Filled.Domain, contentDescription = null) },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
             )
+
             Spacer(Modifier.height(16.dp))
+
             Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                 OutlinedButton(onClick = onBack) { Text("Atrás") }
-                Button(onClick = onNext, enabled = name.text.isNotBlank()) { Text("Continuar") }
+                Button(
+                    onClick = {
+                        val text = name.text.trim()
+                        if (text.isEmpty()) {
+                            scope.launch { snackbar.showSnackbar("Ingresa un nombre válido") }
+                        } else {
+                            vm.saveCompany(text) {
+                                onNext()
+                            }
+                        }
+                    },
+                    enabled = name.text.isNotBlank()
+                ) { Text("Continuar") }
             }
         }
     }
-
-    @Composable
-    fun CreateCompanyScreen(onNext: () -> Unit, onBack: () -> Unit) {
-        val vm = hiltViewModel<WizardViewModel>()
-        // ...
-        Button(onClick = { vm.saveCompany(name.text) { onNext() } }, enabled = name.text.isNotBlank()) {
-            Text("Continuar")
-        }
-    }
 }
-
-

--- a/app/src/main/java/com/deercom/testo11/ui/screens/CreateCompanyScreen.kt
+++ b/app/src/main/java/com/deercom/testo11/ui/screens/CreateCompanyScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.foundation.layout.*
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.deercom.testo11.wizard.WizardViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -27,6 +29,15 @@ fun CreateCompanyScreen(onNext: () -> Unit, onBack: () -> Unit) {
                 OutlinedButton(onClick = onBack) { Text("Atrás") }
                 Button(onClick = onNext, enabled = name.text.isNotBlank()) { Text("Continuar") }
             }
+        }
+    }
+
+    @Composable
+    fun CreateCompanyScreen(onNext: () -> Unit, onBack: () -> Unit) {
+        val vm = hiltViewModel<WizardViewModel>()
+        // ...
+        Button(onClick = { vm.saveCompany(name.text) { onNext() } }, enabled = name.text.isNotBlank()) {
+            Text("Continuar")
         }
     }
 }

--- a/app/src/main/java/com/deercom/testo11/ui/screens/CreateCompanyScreen.kt
+++ b/app/src/main/java/com/deercom/testo11/ui/screens/CreateCompanyScreen.kt
@@ -1,0 +1,34 @@
+package com.deercom.testo11.ui.screens
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Domain
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.foundation.layout.*
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CreateCompanyScreen(onNext: () -> Unit, onBack: () -> Unit) {
+    var name by remember { mutableStateOf(TextFieldValue()) }
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("Crear empresa") }) }
+    ) { pad ->
+        Column(Modifier.padding(pad).padding(16.dp)) {
+            OutlinedTextField(
+                value = name, onValueChange = { name = it },
+                label = { Text("Nombre de la empresa") },
+                leadingIcon = { Icon(Icons.Default.Domain, null) }, singleLine = true, modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(Modifier.height(16.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedButton(onClick = onBack) { Text("Atrás") }
+                Button(onClick = onNext, enabled = name.text.isNotBlank()) { Text("Continuar") }
+            }
+        }
+    }
+}
+
+

--- a/app/src/main/java/com/deercom/testo11/ui/screens/CreateCompanyScreen.kt
+++ b/app/src/main/java/com/deercom/testo11/ui/screens/CreateCompanyScreen.kt
@@ -2,6 +2,8 @@ package com.deercom.testo11.ui.screens
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Domain
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -9,6 +11,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.deercom.testo11.ui.screens.components.AppScaffold
+import com.deercom.testo11.ui.screens.components.AppTopBar
 import com.deercom.testo11.wizard.WizardViewModel
 import kotlinx.coroutines.launch
 
@@ -23,9 +27,8 @@ fun CreateCompanyScreen(
     val snackbar = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
 
-    Scaffold(
-        topBar = { TopAppBar(title = { Text("Crear empresa") }) },
-        snackbarHost = { SnackbarHost(snackbar) }
+    AppScaffold(
+        topBar = { AppTopBar(title = "Crear empresa", navigationIcon = Icons.AutoMirrored.Filled.ArrowBack, onNavigate = onBack) }
     ) { pad ->
         Column(
             Modifier
@@ -52,9 +55,7 @@ fun CreateCompanyScreen(
                         if (text.isEmpty()) {
                             scope.launch { snackbar.showSnackbar("Ingresa un nombre válido") }
                         } else {
-                            vm.saveCompany(text) {
-                                onNext()
-                            }
+                            vm.saveCompany(text) { onNext() }
                         }
                     },
                     enabled = name.text.isNotBlank()

--- a/app/src/main/java/com/deercom/testo11/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/deercom/testo11/ui/screens/HomeScreen.kt
@@ -2,25 +2,31 @@ package com.deercom.testo11.ui.screens
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.deercom.testo11.auth.AuthViewModel
-import kotlinx.coroutines.launch
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.deercom.testo11.home.HomeViewModel
+import com.deercom.testo11.ui.screens.components.AppScaffold
+import com.deercom.testo11.ui.screens.components.AppTopBar
+
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeScreen(
     onLogout: () -> Unit
 ) {
-    val vm = hiltViewModel<AuthViewModel>()
-    val scope = rememberCoroutineScope()
+    val vm: HomeViewModel = hiltViewModel()
+    val companyName = vm.companyName.collectAsStateWithLifecycle().value
+    val alias = vm.alias.collectAsStateWithLifecycle().value
 
-    Scaffold(topBar = { TopAppBar(title = { Text("Home") }) }) { pad ->
+    AppScaffold(
+        topBar = { AppTopBar(title = "Home") }
+    ) { pad ->
         Column(
             modifier = Modifier
                 .padding(pad)
@@ -28,19 +34,12 @@ fun HomeScreen(
                 .fillMaxWidth()
         ) {
             ListItem(
-                headlineContent = { Text("Bienvenido") },
-                supportingContent = { Text("Sesión iniciada (placeholder)") },
+                headlineContent = { Text(companyName.ifBlank { "Empresa" }) },
+                supportingContent = { Text(alias.ifBlank { "Sin alias de sesión" }) },
                 leadingContent = { Icon(Icons.Filled.Home, contentDescription = null) }
             )
             Spacer(Modifier.height(12.dp))
-            OutlinedButton(
-                onClick = {
-                    scope.launch {
-                        vm.logout()
-                        onLogout()
-                    }
-                }
-            ) { Text("Cerrar sesión") }
+            OutlinedButton(onClick = { vm.logout(onLogout) }) { Text("Cerrar sesión") }
         }
     }
 }

--- a/app/src/main/java/com/deercom/testo11/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/deercom/testo11/ui/screens/HomeScreen.kt
@@ -1,27 +1,46 @@
 package com.deercom.testo11.ui.screens
 
+import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
-import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.deercom.testo11.auth.AuthViewModel
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun HomeScreen(onLogout: () -> Unit) {
+fun HomeScreen(
+    onLogout: () -> Unit
+) {
+    val vm = hiltViewModel<AuthViewModel>()
+    val scope = rememberCoroutineScope()
+
     Scaffold(topBar = { TopAppBar(title = { Text("Home") }) }) { pad ->
-        Column(Modifier.padding(pad).padding(16.dp)) {
+        Column(
+            modifier = Modifier
+                .padding(pad)
+                .padding(16.dp)
+                .fillMaxWidth()
+        ) {
             ListItem(
                 headlineContent = { Text("Bienvenido") },
                 supportingContent = { Text("Sesión iniciada (placeholder)") },
-                leadingContent = { Icon(Icons.Default.Home, null) }
+                leadingContent = { Icon(Icons.Filled.Home, contentDescription = null) }
             )
             Spacer(Modifier.height(12.dp))
-            OutlinedButton(onClick = onLogout) { Text("Cerrar sesión") }
+            OutlinedButton(
+                onClick = {
+                    scope.launch {
+                        vm.logout()
+                        onLogout()
+                    }
+                }
+            ) { Text("Cerrar sesión") }
         }
     }
 }
-
-

--- a/app/src/main/java/com/deercom/testo11/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/deercom/testo11/ui/screens/HomeScreen.kt
@@ -1,0 +1,27 @@
+package com.deercom.testo11.ui.screens
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.foundation.layout.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HomeScreen(onLogout: () -> Unit) {
+    Scaffold(topBar = { TopAppBar(title = { Text("Home") }) }) { pad ->
+        Column(Modifier.padding(pad).padding(16.dp)) {
+            ListItem(
+                headlineContent = { Text("Bienvenido") },
+                supportingContent = { Text("Sesión iniciada (placeholder)") },
+                leadingContent = { Icon(Icons.Default.Home, null) }
+            )
+            Spacer(Modifier.height(12.dp))
+            OutlinedButton(onClick = onLogout) { Text("Cerrar sesión") }
+        }
+    }
+}
+
+

--- a/app/src/main/java/com/deercom/testo11/ui/screens/LoginAliasScreen.kt
+++ b/app/src/main/java/com/deercom/testo11/ui/screens/LoginAliasScreen.kt
@@ -20,13 +20,12 @@ fun LoginAliasScreen(
     onBack: () -> Unit
 ) {
     val vm = hiltViewModel<AuthViewModel>()
-    // Leemos el alias guardado en DataStore
     val savedAlias by vm.aliasFlow.collectAsStateWithLifecycle(initialValue = "")
     var alias by remember { mutableStateOf(TextFieldValue("")) }
     val snackbar = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
 
-    // Prefill una vez al tener valor
+    // Prefill una vez cuando exista alias guardado
     LaunchedEffect(savedAlias) {
         if (savedAlias.isNotBlank() && alias.text.isBlank()) {
             alias = TextFieldValue(savedAlias)
@@ -35,7 +34,8 @@ fun LoginAliasScreen(
 
     Scaffold(
         topBar = { TopAppBar(title = { Text("Iniciar sesión") }) },
-        snackbarHost = { SnackbarHost(hostState = snackbar) }
+        snackbarHost = { SnackbarHost(hostState = snackbar) },
+        contentWindowInsets = WindowInsets.safeDrawing
     ) { pad ->
         Column(
             modifier = Modifier
@@ -52,12 +52,6 @@ fun LoginAliasScreen(
                 modifier = Modifier.fillMaxWidth()
             )
 
-            // 🔎 Línea de ayuda temporal para depurar
-            AssistChip(
-                onClick = {},
-                label = { Text(if (savedAlias.isBlank()) "Alias guardado: (vacío)" else "Alias guardado: $savedAlias") }
-            )
-
             Spacer(Modifier.height(16.dp))
 
             Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
@@ -65,18 +59,9 @@ fun LoginAliasScreen(
                 Button(
                     onClick = {
                         scope.launch {
-                            val input = alias.text.trim()
-                            val ok = vm.isAliasValid(input)
-                            if (ok) {
-                                onSuccess()
-                            } else {
-                                // Si no hay alias guardado, mensaje específico
-                                val msg = if (savedAlias.isBlank())
-                                    "No hay alias guardado. Completa el wizard primero."
-                                else
-                                    "Alias incorrecto. Usa exactamente el alias creado en el wizard."
-                                snackbar.showSnackbar(msg)
-                            }
+                            val ok = vm.isAliasValid(alias.text.trim())
+                            if (ok) onSuccess()
+                            else snackbar.showSnackbar("Alias incorrecto. Usa exactamente el alias creado en el wizard.")
                         }
                     },
                     enabled = alias.text.isNotBlank()

--- a/app/src/main/java/com/deercom/testo11/ui/screens/LoginAliasScreen.kt
+++ b/app/src/main/java/com/deercom/testo11/ui/screens/LoginAliasScreen.kt
@@ -1,29 +1,87 @@
 package com.deercom.testo11.ui.screens
 
+import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Login
+import androidx.compose.material.icons.automirrored.filled.Login
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
-import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.foundation.layout.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.deercom.testo11.auth.AuthViewModel
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun LoginAliasScreen(onSuccess: () -> Unit, onBack: () -> Unit) {
-    var alias by remember { mutableStateOf(TextFieldValue()) }
-    Scaffold(topBar = { TopAppBar(title = { Text("Iniciar sesión") }) }) { pad ->
-        Column(Modifier.padding(pad).padding(16.dp)) {
-            OutlinedTextField(value = alias, onValueChange = { alias = it }, label = { Text("Alias") },
-                leadingIcon = { Icon(Icons.Default.Login, null) }, singleLine = true, modifier = Modifier.fillMaxWidth())
+fun LoginAliasScreen(
+    onSuccess: () -> Unit,
+    onBack: () -> Unit
+) {
+    val vm = hiltViewModel<AuthViewModel>()
+    // Leemos el alias guardado en DataStore
+    val savedAlias by vm.aliasFlow.collectAsStateWithLifecycle(initialValue = "")
+    var alias by remember { mutableStateOf(TextFieldValue("")) }
+    val snackbar = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+
+    // Prefill una vez al tener valor
+    LaunchedEffect(savedAlias) {
+        if (savedAlias.isNotBlank() && alias.text.isBlank()) {
+            alias = TextFieldValue(savedAlias)
+        }
+    }
+
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("Iniciar sesión") }) },
+        snackbarHost = { SnackbarHost(hostState = snackbar) }
+    ) { pad ->
+        Column(
+            modifier = Modifier
+                .padding(pad)
+                .padding(16.dp)
+                .fillMaxWidth()
+        ) {
+            OutlinedTextField(
+                value = alias,
+                onValueChange = { alias = it },
+                label = { Text("Alias") },
+                leadingIcon = { Icon(Icons.AutoMirrored.Filled.Login, contentDescription = null) },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            // 🔎 Línea de ayuda temporal para depurar
+            AssistChip(
+                onClick = {},
+                label = { Text(if (savedAlias.isBlank()) "Alias guardado: (vacío)" else "Alias guardado: $savedAlias") }
+            )
+
             Spacer(Modifier.height(16.dp))
+
             Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                 OutlinedButton(onClick = onBack) { Text("Atrás") }
-                Button(onClick = onSuccess, enabled = alias.text.isNotBlank()) { Text("Entrar") }
+                Button(
+                    onClick = {
+                        scope.launch {
+                            val input = alias.text.trim()
+                            val ok = vm.isAliasValid(input)
+                            if (ok) {
+                                onSuccess()
+                            } else {
+                                // Si no hay alias guardado, mensaje específico
+                                val msg = if (savedAlias.isBlank())
+                                    "No hay alias guardado. Completa el wizard primero."
+                                else
+                                    "Alias incorrecto. Usa exactamente el alias creado en el wizard."
+                                snackbar.showSnackbar(msg)
+                            }
+                        }
+                    },
+                    enabled = alias.text.isNotBlank()
+                ) { Text("Entrar") }
             }
         }
     }
 }
-
-

--- a/app/src/main/java/com/deercom/testo11/ui/screens/LoginAliasScreen.kt
+++ b/app/src/main/java/com/deercom/testo11/ui/screens/LoginAliasScreen.kt
@@ -1,0 +1,29 @@
+package com.deercom.testo11.ui.screens
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Login
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.foundation.layout.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LoginAliasScreen(onSuccess: () -> Unit, onBack: () -> Unit) {
+    var alias by remember { mutableStateOf(TextFieldValue()) }
+    Scaffold(topBar = { TopAppBar(title = { Text("Iniciar sesión") }) }) { pad ->
+        Column(Modifier.padding(pad).padding(16.dp)) {
+            OutlinedTextField(value = alias, onValueChange = { alias = it }, label = { Text("Alias") },
+                leadingIcon = { Icon(Icons.Default.Login, null) }, singleLine = true, modifier = Modifier.fillMaxWidth())
+            Spacer(Modifier.height(16.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedButton(onClick = onBack) { Text("Atrás") }
+                Button(onClick = onSuccess, enabled = alias.text.isNotBlank()) { Text("Entrar") }
+            }
+        }
+    }
+}
+
+

--- a/app/src/main/java/com/deercom/testo11/ui/screens/LoginAliasScreen.kt
+++ b/app/src/main/java/com/deercom/testo11/ui/screens/LoginAliasScreen.kt
@@ -2,7 +2,9 @@ package com.deercom.testo11.ui.screens
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Login
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
@@ -11,9 +13,10 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.deercom.testo11.auth.AuthViewModel
+import com.deercom.testo11.ui.screens.components.AppScaffold
+import com.deercom.testo11.ui.screens.components.AppTopBar
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LoginAliasScreen(
     onSuccess: () -> Unit,
@@ -32,10 +35,8 @@ fun LoginAliasScreen(
         }
     }
 
-    Scaffold(
-        topBar = { TopAppBar(title = { Text("Iniciar sesión") }) },
-        snackbarHost = { SnackbarHost(hostState = snackbar) },
-        contentWindowInsets = WindowInsets.safeDrawing
+    AppScaffold(
+        topBar = { AppTopBar(title = "Iniciar sesión", navigationIcon = Icons.AutoMirrored.Filled.ArrowBack, onNavigate = onBack) }
     ) { pad ->
         Column(
             modifier = Modifier

--- a/app/src/main/java/com/deercom/testo11/ui/screens/ProfileCardScreen.kt
+++ b/app/src/main/java/com/deercom/testo11/ui/screens/ProfileCardScreen.kt
@@ -2,6 +2,8 @@ package com.deercom.testo11.ui.screens
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Badge
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -10,6 +12,8 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.deercom.testo11.profile.ProfileViewModel
+import com.deercom.testo11.ui.screens.components.AppScaffold
+import com.deercom.testo11.ui.screens.components.AppTopBar
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -19,13 +23,12 @@ fun ProfileCardScreen(
 ) {
     val vm: ProfileViewModel = hiltViewModel()
 
-    var name by remember { mutableStateOf(TextFieldValue(vm.name.value)) }
+    var name  by remember { mutableStateOf(TextFieldValue(vm.name.value)) }
     var phone by remember { mutableStateOf(TextFieldValue(vm.phone.value)) }
     var docId by remember { mutableStateOf(TextFieldValue(vm.docId.value)) }
 
-    Scaffold(
-        topBar = { TopAppBar(title = { Text("Perfil") }) },
-        contentWindowInsets = WindowInsets.safeDrawing
+    AppScaffold(
+        topBar = { AppTopBar(title = "Perfil", navigationIcon = Icons.AutoMirrored.Filled.ArrowBack, onNavigate = onBack) }
     ) { pad ->
         Column(
             modifier = Modifier
@@ -34,23 +37,30 @@ fun ProfileCardScreen(
                 .fillMaxWidth()
         ) {
             OutlinedTextField(
-                value = name, onValueChange = { name = it },
+                value = name,
+                onValueChange = { name = it },
                 label = { Text("Nombre") },
                 leadingIcon = { Icon(Icons.Filled.Badge, contentDescription = null) },
-                singleLine = true, modifier = Modifier.fillMaxWidth()
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
             )
             Spacer(Modifier.height(8.dp))
             OutlinedTextField(
-                value = phone, onValueChange = { phone = it },
+                value = phone,
+                onValueChange = { phone = it },
                 label = { Text("Teléfono") },
-                singleLine = true, modifier = Modifier.fillMaxWidth()
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
             )
             Spacer(Modifier.height(8.dp))
             OutlinedTextField(
-                value = docId, onValueChange = { docId = it },
+                value = docId,
+                onValueChange = { docId = it },
                 label = { Text("Documento") },
-                singleLine = true, modifier = Modifier.fillMaxWidth()
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
             )
+
             Spacer(Modifier.height(16.dp))
             Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                 OutlinedButton(onClick = onBack) { Text("Atrás") }

--- a/app/src/main/java/com/deercom/testo11/ui/screens/ProfileCardScreen.kt
+++ b/app/src/main/java/com/deercom/testo11/ui/screens/ProfileCardScreen.kt
@@ -1,33 +1,64 @@
 package com.deercom.testo11.ui.screens
 
+import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Badge
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
-import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.foundation.layout.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.deercom.testo11.profile.ProfileViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ProfileCardScreen(onNext: () -> Unit, onBack: () -> Unit) {
-    var name by remember { mutableStateOf(TextFieldValue()) }
-    var phone by remember { mutableStateOf(TextFieldValue()) }
-    Scaffold(topBar = { TopAppBar(title = { Text("Perfil") }) }) { pad ->
-        Column(Modifier.padding(pad).padding(16.dp)) {
-            OutlinedTextField(value = name, onValueChange = { name = it }, label = { Text("Nombre") },
-                leadingIcon = { Icon(Icons.Default.Badge, null) }, singleLine = true, modifier = Modifier.fillMaxWidth())
+fun ProfileCardScreen(
+    onNext: () -> Unit,
+    onBack: () -> Unit
+) {
+    val vm: ProfileViewModel = hiltViewModel()
+
+    var name by remember { mutableStateOf(TextFieldValue(vm.name.value)) }
+    var phone by remember { mutableStateOf(TextFieldValue(vm.phone.value)) }
+    var docId by remember { mutableStateOf(TextFieldValue(vm.docId.value)) }
+
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("Perfil") }) },
+        contentWindowInsets = WindowInsets.safeDrawing
+    ) { pad ->
+        Column(
+            modifier = Modifier
+                .padding(pad)
+                .padding(16.dp)
+                .fillMaxWidth()
+        ) {
+            OutlinedTextField(
+                value = name, onValueChange = { name = it },
+                label = { Text("Nombre") },
+                leadingIcon = { Icon(Icons.Filled.Badge, contentDescription = null) },
+                singleLine = true, modifier = Modifier.fillMaxWidth()
+            )
             Spacer(Modifier.height(8.dp))
-            OutlinedTextField(value = phone, onValueChange = { phone = it }, label = { Text("Teléfono") },
-                singleLine = true, modifier = Modifier.fillMaxWidth())
+            OutlinedTextField(
+                value = phone, onValueChange = { phone = it },
+                label = { Text("Teléfono") },
+                singleLine = true, modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = docId, onValueChange = { docId = it },
+                label = { Text("Documento") },
+                singleLine = true, modifier = Modifier.fillMaxWidth()
+            )
             Spacer(Modifier.height(16.dp))
             Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                 OutlinedButton(onClick = onBack) { Text("Atrás") }
-                Button(onClick = onNext, enabled = name.text.isNotBlank()) { Text("Continuar") }
+                Button(
+                    onClick = { vm.save(name.text, phone.text, docId.text, onNext) },
+                    enabled = name.text.isNotBlank()
+                ) { Text("Guardar y continuar") }
             }
         }
     }
 }
-
-

--- a/app/src/main/java/com/deercom/testo11/ui/screens/ProfileCardScreen.kt
+++ b/app/src/main/java/com/deercom/testo11/ui/screens/ProfileCardScreen.kt
@@ -1,0 +1,33 @@
+package com.deercom.testo11.ui.screens
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Badge
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.foundation.layout.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProfileCardScreen(onNext: () -> Unit, onBack: () -> Unit) {
+    var name by remember { mutableStateOf(TextFieldValue()) }
+    var phone by remember { mutableStateOf(TextFieldValue()) }
+    Scaffold(topBar = { TopAppBar(title = { Text("Perfil") }) }) { pad ->
+        Column(Modifier.padding(pad).padding(16.dp)) {
+            OutlinedTextField(value = name, onValueChange = { name = it }, label = { Text("Nombre") },
+                leadingIcon = { Icon(Icons.Default.Badge, null) }, singleLine = true, modifier = Modifier.fillMaxWidth())
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(value = phone, onValueChange = { phone = it }, label = { Text("Teléfono") },
+                singleLine = true, modifier = Modifier.fillMaxWidth())
+            Spacer(Modifier.height(16.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedButton(onClick = onBack) { Text("Atrás") }
+                Button(onClick = onNext, enabled = name.text.isNotBlank()) { Text("Continuar") }
+            }
+        }
+    }
+}
+
+

--- a/app/src/main/java/com/deercom/testo11/ui/screens/StartRouterScreen.kt
+++ b/app/src/main/java/com/deercom/testo11/ui/screens/StartRouterScreen.kt
@@ -2,10 +2,7 @@ package com.deercom.testo11.ui.screens
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
@@ -13,8 +10,8 @@ import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.deercom.testo11.start.StartViewModel
+import com.deercom.testo11.ui.screens.components.AppScaffold
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun StartRouterScreen(
     goWizard: () -> Unit,
@@ -25,23 +22,15 @@ fun StartRouterScreen(
     val alias = vm.alias.collectAsStateWithLifecycle().value
 
     LaunchedEffect(companyName, alias) {
-        if (companyName.isBlank() || alias.isBlank()) {
-            goWizard()
-        } else {
-            goLogin()
-        }
+        if (companyName.isBlank() || alias.isBlank()) goWizard()
+        else goLogin()
     }
 
-    Scaffold { paddingValues ->
-        Box(
-            Modifier
-                .fillMaxSize()
-                .padding(paddingValues),
-            contentAlignment = Alignment.Center
-        ) {
+    AppScaffold(
+        topBar = { /* sin top bar en el splash/router */ }
+    ) { _ ->
+        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
             CircularProgressIndicator()
         }
     }
 }
-
-

--- a/app/src/main/java/com/deercom/testo11/ui/screens/StartRouterScreen.kt
+++ b/app/src/main/java/com/deercom/testo11/ui/screens/StartRouterScreen.kt
@@ -1,0 +1,47 @@
+package com.deercom.testo11.ui.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.deercom.testo11.start.StartViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StartRouterScreen(
+    goWizard: () -> Unit,
+    goLogin: () -> Unit
+) {
+    val vm: StartViewModel = hiltViewModel()
+    val companyName = vm.companyName.collectAsStateWithLifecycle().value
+    val alias = vm.alias.collectAsStateWithLifecycle().value
+
+    LaunchedEffect(companyName, alias) {
+        if (companyName.isBlank() || alias.isBlank()) {
+            goWizard()
+        } else {
+            goLogin()
+        }
+    }
+
+    Scaffold { paddingValues ->
+        Box(
+            Modifier
+                .fillMaxSize()
+                .padding(paddingValues),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator()
+        }
+    }
+}
+
+

--- a/app/src/main/java/com/deercom/testo11/ui/screens/WizardStartScreen.kt
+++ b/app/src/main/java/com/deercom/testo11/ui/screens/WizardStartScreen.kt
@@ -1,0 +1,25 @@
+package com.deercom.testo11.ui.screens
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Flag
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WizardStartScreen(onNext: () -> Unit) {
+    Scaffold(topBar = { TopAppBar(title = { Text("Configuración inicial") }) }) { pad ->
+        ElevatedCard(Modifier.padding(pad).padding(16.dp)) {
+            ListItem(
+                headlineContent = { Text("Bienvenido") },
+                supportingContent = { Text("Inicia el asistente para crear tu empresa y el Admin Master.") },
+                leadingContent = { Icon(Icons.Default.Flag, contentDescription = null) }
+            )
+            Button(onClick = onNext, modifier = Modifier.padding(16.dp)) { Text("Comenzar") }
+        }
+    }
+}
+

--- a/app/src/main/java/com/deercom/testo11/ui/screens/components/AppScaffold.kt
+++ b/app/src/main/java/com/deercom/testo11/ui/screens/components/AppScaffold.kt
@@ -1,0 +1,21 @@
+package com.deercom.testo11.ui.screens.components
+
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.foundation.layout.PaddingValues
+
+@Composable
+fun AppScaffold(
+    topBar: @Composable () -> Unit,
+    content: @Composable (PaddingValues) -> Unit
+) {
+    Scaffold(
+        topBar = topBar,
+        contentWindowInsets = WindowInsets.safeDrawing,
+        content = content
+    )
+}
+
+

--- a/app/src/main/java/com/deercom/testo11/ui/screens/components/AppTopBar.kt
+++ b/app/src/main/java/com/deercom/testo11/ui/screens/components/AppTopBar.kt
@@ -1,0 +1,30 @@
+package com.deercom.testo11.ui.screens.components
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AppTopBar(
+    title: String,
+    navigationIcon: ImageVector? = null,
+    onNavigate: (() -> Unit)? = null,
+    actions: @Composable () -> Unit = {}
+) {
+    TopAppBar(
+        title = { Text(title) },
+        navigationIcon = {
+            if (navigationIcon != null && onNavigate != null) {
+                IconButton(onClick = onNavigate) {
+                    Icon(navigationIcon, contentDescription = null)
+                }
+            }
+        },
+        actions = { actions() }
+    )
+}

--- a/app/src/main/java/com/deercom/testo11/ui/screens/home/HomeWithBottomBarScreen.kt
+++ b/app/src/main/java/com/deercom/testo11/ui/screens/home/HomeWithBottomBarScreen.kt
@@ -1,0 +1,66 @@
+package com.deercom.testo11.ui.screens.home
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Business
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Groups
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.foundation.layout.*
+import androidx.compose.ui.unit.dp
+import com.deercom.testo11.data.User
+import com.deercom.testo11.ui.screens.components.AppScaffold
+import com.deercom.testo11.ui.screens.components.AppTopBar
+import com.deercom.testo11.ui.screens.users.UsersListScreen
+
+@Composable
+fun HomeWithBottomBarScreen(
+    onEditUser: (User) -> Unit
+) {
+    var tab by remember { mutableStateOf(0) }
+    val items = listOf("Usuarios", "Inicio", "Empresa", "Ajustes")
+    val icons = listOf(Icons.Filled.Groups, Icons.Filled.Home, Icons.Filled.Business, Icons.Filled.Settings)
+
+    AppScaffold(
+        topBar = { AppTopBar(title = items[tab]) }
+    ) { pad ->
+        Scaffold(
+            modifier = Modifier.padding(pad),
+            bottomBar = {
+                NavigationBar {
+                    items.forEachIndexed { index, label ->
+                        NavigationBarItem(
+                            selected = tab == index,
+                            onClick = { tab = index },
+                            icon = { Icon(icons[index], contentDescription = label) },
+                            label = { Text(label) }
+                        )
+                    }
+                }
+            }
+        ) { inner ->
+            Box(Modifier.padding(inner).fillMaxSize()) {
+                when (tab) {
+                    0 -> UsersListScreen(onEdit = onEditUser)
+                    1 -> Placeholder("Inicio")
+                    2 -> Placeholder("Empresa")
+                    3 -> Placeholder("Ajustes")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun Placeholder(text: String) {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text("Sección: $text")
+        Text("Contenido en construcción.")
+    }
+}
+

--- a/app/src/main/java/com/deercom/testo11/ui/screens/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/deercom/testo11/ui/screens/onboarding/OnboardingScreen.kt
@@ -1,0 +1,209 @@
+package com.deercom.testo11.ui.screens.onboarding
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Business
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.PhotoCamera
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardOptions
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.deercom.testo11.onboarding.OnboardingViewModel
+import com.deercom.testo11.ui.screens.components.AppScaffold
+import com.deercom.testo11.ui.screens.components.AppTopBar
+
+@Composable
+fun OnboardingScreen(
+    onFinishFirstTime: () -> Unit,
+    onFinishFromHome: () -> Unit
+) {
+    val vm: OnboardingViewModel = hiltViewModel()
+    val s by vm.state.collectAsState()
+
+    var tab by remember { mutableStateOf(0) }
+    val tabs = listOf("Empresa", "Perfil", "Seguridad", "Foto")
+
+    AppScaffold(
+        topBar = {
+            AppTopBar(
+                title = "Alta inicial",
+                navigationIcon = Icons.Filled.ArrowBack,
+                onNavigate = { /* back se maneja desde NavGraph */ }
+            )
+        }
+    ) { pad ->
+        Column(
+            modifier = Modifier
+                .padding(pad)
+                .fillMaxSize()
+                .imePadding(),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            ScrollableTabRow(selectedTabIndex = tab) {
+                tabs.forEachIndexed { i, title ->
+                    Tab(
+                        selected = tab == i,
+                        onClick = { tab = i },
+                        text = { Text(title) }
+                    )
+                }
+            }
+
+            Card(
+                modifier = Modifier
+                    .padding(16.dp)
+                    .fillMaxWidth()
+                    .widthIn(max = 480.dp),
+                elevation = CardDefaults.cardElevation(2.dp)
+            ) {
+                Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    when (tab) {
+                        0 -> EmpresaTab(s, vm)
+                        1 -> PerfilTab(s, vm)
+                        2 -> SeguridadTab(s, vm)
+                        3 -> FotoTab(s, vm)
+                    }
+                    Spacer(Modifier.height(8.dp))
+                    Row(horizontalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.fillMaxWidth()) {
+                        OutlinedButton(
+                            onClick = { vm.save(onSaved = onFinishFromHome) },
+                            modifier = Modifier.weight(1f)
+                        ) { Text("Guardar borrador") }
+                        Button(
+                            onClick = { vm.save(onSaved = onFinishFirstTime) },
+                            modifier = Modifier.weight(1f)
+                        ) { Text("Guardar y finalizar") }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmpresaTab(s: OnboardingViewModel.UiState, vm: OnboardingViewModel) {
+    OutlinedTextField(
+        value = s.empresaNombre,
+        onValueChange = { new -> vm.update { it.copy(empresaNombre = new) } },
+        label = { Text("Nombre de la empresa") },
+        leadingIcon = { Icon(Icons.Filled.Business, null) },
+        modifier = Modifier.fillMaxWidth()
+    )
+    OutlinedTextField(
+        value = s.ruc,
+        onValueChange = { new -> vm.update { it.copy(ruc = new) } },
+        label = { Text("RUC / NIT / ID fiscal") },
+        modifier = Modifier.fillMaxWidth()
+    )
+    OutlinedTextField(
+        value = s.localidad,
+        onValueChange = { new -> vm.update { it.copy(localidad = new) } },
+        label = { Text("Localidad (código)") },
+        modifier = Modifier.fillMaxWidth()
+    )
+    AssistChip(onClick = { vm.regenerateAlias() }, label = { Text("Sugerir alias con localidad") })
+}
+
+@Composable
+private fun PerfilTab(s: OnboardingViewModel.UiState, vm: OnboardingViewModel) {
+    OutlinedTextField(
+        value = s.alias,
+        onValueChange = { new -> vm.update { it.copy(alias = new) } },
+        label = { Text("Usuario (alias)") },
+        leadingIcon = { Icon(Icons.Filled.Person, null) },
+        modifier = Modifier.fillMaxWidth()
+    )
+    Row(horizontalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.fillMaxWidth()) {
+        OutlinedTextField(
+            value = s.nombres,
+            onValueChange = { new -> vm.update { it.copy(nombres = new) } },
+            label = { Text("Nombres") },
+            modifier = Modifier.weight(1f),
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next)
+        )
+        OutlinedTextField(
+            value = s.apellidos,
+            onValueChange = { new -> vm.update { it.copy(apellidos = new) } },
+            label = { Text("Apellidos") },
+            modifier = Modifier.weight(1f),
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done)
+        )
+    }
+    OutlinedTextField(
+        value = s.cargo,
+        onValueChange = { new -> vm.update { it.copy(cargo = new) } },
+        label = { Text("Cargo") },
+        modifier = Modifier.fillMaxWidth()
+    )
+    OutlinedTextField(
+        value = s.documento,
+        onValueChange = { new -> vm.update { it.copy(documento = new) } },
+        label = { Text("Documento (ID)") },
+        modifier = Modifier.fillMaxWidth()
+    )
+    OutlinedTextField(
+        value = s.telefonoPersonal,
+        onValueChange = { new -> vm.update { it.copy(telefonoPersonal = new) } },
+        label = { Text("Teléfono personal") },
+        modifier = Modifier.fillMaxWidth()
+    )
+    OutlinedTextField(
+        value = s.telefonoDispositivo,
+        onValueChange = { new -> vm.update { it.copy(telefonoDispositivo = new) } },
+        label = { Text("Teléfono del dispositivo") },
+        trailingIcon = {
+            AssistChip(onClick = { /* Placeholder: Phone Number Hint en implementación */ }, label = { Text("Sugerir número") })
+        },
+        modifier = Modifier.fillMaxWidth()
+    )
+}
+
+@Composable
+private fun SeguridadTab(s: OnboardingViewModel.UiState, vm: OnboardingViewModel) {
+    var show1 by remember { mutableStateOf(false) }
+    var show2 by remember { mutableStateOf(false) }
+    OutlinedTextField(
+        value = s.password,
+        onValueChange = { new -> vm.update { it.copy(password = new) } },
+        label = { Text("Contraseña") },
+        visualTransformation = if (show1) VisualTransformation.None else PasswordVisualTransformation(),
+        trailingIcon = {
+            TextButton(onClick = { show1 = !show1 }) { Text(if (show1) "Ocultar" else "Ver") }
+        },
+        modifier = Modifier.fillMaxWidth()
+    )
+    OutlinedTextField(
+        value = s.passwordConfirm,
+        onValueChange = { new -> vm.update { it.copy(passwordConfirm = new) } },
+        label = { Text("Confirmar contraseña") },
+        visualTransformation = if (show2) VisualTransformation.None else PasswordVisualTransformation(),
+        trailingIcon = {
+            TextButton(onClick = { show2 = !show2 }) { Text(if (show2) "Ocultar" else "Ver") }
+        },
+        modifier = Modifier.fillMaxWidth()
+    )
+    // Indicador simple (informativo)
+    LinearProgressIndicator(progress = { (s.password.length.coerceAtMost(12)) / 12f })
+}
+
+@Composable
+private fun FotoTab(s: OnboardingViewModel.UiState, vm: OnboardingViewModel) {
+    OutlinedTextField(
+        value = s.fotoUri,
+        onValueChange = { new -> vm.update { it.copy(fotoUri = new) } },
+        label = { Text("Foto (URI)") },
+        leadingIcon = { Icon(Icons.Filled.PhotoCamera, null) },
+        modifier = Modifier.fillMaxWidth()
+    )
+    Text("En producción: tomar foto / galería + recorte y compresión.")
+}
+

--- a/app/src/main/java/com/deercom/testo11/ui/screens/users/UsersListScreen.kt
+++ b/app/src/main/java/com/deercom/testo11/ui/screens/users/UsersListScreen.kt
@@ -1,0 +1,72 @@
+package com.deercom.testo11.ui.screens.users
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Groups
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.deercom.testo11.data.User
+import com.deercom.testo11.users.UsersViewModel
+
+@Composable
+fun UsersListScreen(
+    onEdit: (User) -> Unit
+) {
+    val vm: UsersViewModel = hiltViewModel()
+    val users by vm.users.collectAsState()
+
+    var selected by remember { mutableStateOf<User?>(null) }
+
+    Column(Modifier.fillMaxSize().padding(16.dp)) {
+        ListItem(
+            leadingContent = { Icon(Icons.Filled.Groups, null) },
+            headlineContent = { Text("Usuarios (${users.size})") },
+            supportingContent = { Text("Toque un usuario para ver detalle") }
+        )
+        Spacer(Modifier.height(8.dp))
+        LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxSize()) {
+            items(users) { u ->
+                ElevatedCard(
+                    modifier = Modifier.fillMaxWidth().clickable { selected = u }
+                ) {
+                    ListItem(
+                        headlineContent = { Text("${u.nombres} ${u.apellidos}".trim()) },
+                        supportingContent = { Text("${u.alias} • ${u.cargo.ifBlank { "Sin cargo" }}") }
+                    )
+                }
+            }
+        }
+    }
+
+    if (selected != null) {
+        val u = selected!!
+        AlertDialog(
+            onDismissRequest = { selected = null },
+            confirmButton = {
+                TextButton(onClick = { onEdit(u); selected = null }) {
+                    Icon(Icons.Filled.Edit, null); Spacer(Modifier.width(6.dp)); Text("Editar")
+                }
+            },
+            dismissButton = { TextButton(onClick = { selected = null }) { Text("Cerrar") } },
+            title = { Text("${u.nombres} ${u.apellidos}".trim()) },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                    Text("Usuario: ${u.alias}")
+                    Text("Cargo: ${u.cargo.ifBlank { "—" }}")
+                    Text("Documento: ${u.documento.ifBlank { "—" }}")
+                    Text("Tel. personal: ${u.telefonoPersonal.ifBlank { "—" }}")
+                    Text("Tel. dispositivo: ${u.telefonoDispositivo.ifBlank { "—" }}")
+                    Text("Localidad: ${u.localidad.ifBlank { "—" }}")
+                }
+            }
+        )
+    }
+}
+

--- a/app/src/main/java/com/deercom/testo11/users/UsersViewModel.kt
+++ b/app/src/main/java/com/deercom/testo11/users/UsersViewModel.kt
@@ -1,0 +1,21 @@
+package com.deercom.testo11.users
+
+import androidx.lifecycle.ViewModel
+import com.deercom.testo11.data.LocalUserRepository
+import com.deercom.testo11.data.User
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+@HiltViewModel
+class UsersViewModel @Inject constructor(
+    repo: LocalUserRepository
+) : ViewModel() {
+    val users: StateFlow<List<User>> =
+        repo.usersFlow().map { it.sortedBy { u -> u.alias } }
+            .stateIn(kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.Main), SharingStarted.Lazily, emptyList())
+}
+

--- a/app/src/main/java/com/deercom/testo11/wizard/WizardViewModel.kt
+++ b/app/src/main/java/com/deercom/testo11/wizard/WizardViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.deercom.testo11.data.SessionStore
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.first
 import java.util.UUID
 import javax.inject.Inject
 
@@ -13,8 +14,7 @@ class WizardViewModel @Inject constructor(
     private val session: SessionStore
 ) : ViewModel() {
 
-    fun saveCompany(name: String, onSaved: (String) -> Unit) {
-        // por ahora generamos un id local
+    fun saveCompany(@Suppress("UNUSED_PARAMETER") name: String, onSaved: (String) -> Unit) {
         val id = UUID.randomUUID().toString()
         viewModelScope.launch {
             session.setCompanyId(id)
@@ -22,12 +22,17 @@ class WizardViewModel @Inject constructor(
         }
     }
 
-    fun saveAdminAlias(alias: String, onSaved: () -> Unit) {
+    /** Guarda el alias y valida que quedó persistido antes de continuar. */
+    fun saveAdminAlias(alias: String, onSaved: () -> Unit, onError: (String) -> Unit = {}) {
         viewModelScope.launch {
-            session.setAlias(alias)
-            onSaved()
+            session.setAlias(alias.trim())
+            // Verificamos inmediatamente
+            val persisted = session.aliasFlow.first()
+            if (persisted.equals(alias.trim(), ignoreCase = true)) {
+                onSaved()
+            } else {
+                onError("No se pudo confirmar el guardado del alias.")
+            }
         }
     }
 }
-
-

--- a/app/src/main/java/com/deercom/testo11/wizard/WizardViewModel.kt
+++ b/app/src/main/java/com/deercom/testo11/wizard/WizardViewModel.kt
@@ -4,8 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.deercom.testo11.data.SessionStore
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import java.util.UUID
 import javax.inject.Inject
 
@@ -14,10 +14,11 @@ class WizardViewModel @Inject constructor(
     private val session: SessionStore
 ) : ViewModel() {
 
-    fun saveCompany(@Suppress("UNUSED_PARAMETER") name: String, onSaved: (String) -> Unit) {
+    fun saveCompany(name: String, onSaved: (String) -> Unit) {
         val id = UUID.randomUUID().toString()
         viewModelScope.launch {
             session.setCompanyId(id)
+            session.setCompanyName(name.trim())
             onSaved(id)
         }
     }
@@ -26,13 +27,9 @@ class WizardViewModel @Inject constructor(
     fun saveAdminAlias(alias: String, onSaved: () -> Unit, onError: (String) -> Unit = {}) {
         viewModelScope.launch {
             session.setAlias(alias.trim())
-            // Verificamos inmediatamente
             val persisted = session.aliasFlow.first()
-            if (persisted.equals(alias.trim(), ignoreCase = true)) {
-                onSaved()
-            } else {
-                onError("No se pudo confirmar el guardado del alias.")
-            }
+            if (persisted.equals(alias.trim(), ignoreCase = true)) onSaved()
+            else onError("No se pudo confirmar el guardado del alias.")
         }
     }
 }

--- a/app/src/main/java/com/deercom/testo11/wizard/WizardViewModel.kt
+++ b/app/src/main/java/com/deercom/testo11/wizard/WizardViewModel.kt
@@ -1,0 +1,33 @@
+package com.deercom.testo11.wizard
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.deercom.testo11.data.SessionStore
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import java.util.UUID
+import javax.inject.Inject
+
+@HiltViewModel
+class WizardViewModel @Inject constructor(
+    private val session: SessionStore
+) : ViewModel() {
+
+    fun saveCompany(name: String, onSaved: (String) -> Unit) {
+        // por ahora generamos un id local
+        val id = UUID.randomUUID().toString()
+        viewModelScope.launch {
+            session.setCompanyId(id)
+            onSaved(id)
+        }
+    }
+
+    fun saveAdminAlias(alias: String, onSaved: () -> Unit) {
+        viewModelScope.launch {
+            session.setAlias(alias)
+            onSaved()
+        }
+    }
+}
+
+

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,4 +1,6 @@
-
 <resources>
-    <style name="Theme.Material3.DayNight.NoActionBar" parent="Theme.Material3.DayNight.NoActionBar" />
+    <!-- Tema base SIN ActionBar -->
+    <style name="Theme.Testo11" parent="android:Theme.Material.NoActionBar">
+        <!-- El atributo windowLayoutInDisplayCutoutMode requiere API 27+ -->
+    </style>
 </resources>


### PR DESCRIPTION
- Navegación Compose con rutas: WizardStart → CreateCompany → CreateAdminUser → ProfileCard → LoginAlias → Home
- Pantallas base en M3 (placeholders, sin lógica de negocio).
- MainActivity con NavHost y tema M3.
- Estructura limpia para continuar con persistencia (DataStore) y sesiones por alias.

Checklist:
- [x] Compila en AGP 8.3.2 / Kotlin 1.9.24 / compileSdk 34
- [x] Navegación entre pantallas funciona
- [ ] Conectar DataStore para alias/companyId (siguiente PR)
